### PR TITLE
Add special handling for update select fields

### DIFF
--- a/yaks/lib/yaks/resource/form.rb
+++ b/yaks/lib/yaks/resource/form.rb
@@ -22,6 +22,18 @@ module Yaks
           end
         end
       end
+
+      def map_fields(fields = fields, &block)
+        with(
+             fields: fields.map do |field|
+               if field.type.equal? :fieldset
+                 field.with(fields: field.fields.map(&block))
+               else
+                 block.call(field)
+               end
+             end
+        )
+      end
     end
   end
 end

--- a/yaks/lib/yaks/resource/form/field.rb
+++ b/yaks/lib/yaks/resource/form/field.rb
@@ -6,11 +6,39 @@ module Yaks
 
         def value
           if type.equal? :select
-            selected = options.find { |option| option.selected }
+            selected = options.find(&:selected)
             selected.value if selected
           else
             @value
           end
+        end
+
+        def with_value(attributes)
+          if type.equal? :select
+            with(with_select_options(attributes))
+          else
+            with(attributes)
+          end
+        end
+
+        private
+
+        def with_select_options(attributes)
+          unset = ->(option) { option.selected && !(option.value == attributes[:value]) }
+          set   = ->(option) { !option.selected && (option.value == attributes[:value]) }
+
+          new_options = options.reduce([]) do |new_opts, option|
+            new_opts << case option
+                        when unset
+                          option.update selected: false
+                        when set
+                          option.update selected: true
+                        else
+                          option
+                        end
+          end
+
+          attributes.merge(options: new_options)
         end
       end
     end


### PR DESCRIPTION
As the select-fields behave a bit differently from the regular value
fields we need to handle updating these in a different manner, as it is
a two step thing.

First update the options, then update the select-field.

This commit contains the change required to do this.