### PR TITLE
Fix yaks-sinatra

### DIFF
--- a/yaks-sinatra/lib/yaks-sinatra.rb
+++ b/yaks-sinatra/lib/yaks-sinatra.rb
@@ -22,7 +22,7 @@ module Sinatra
     def yaks(object, opts = {})
       runner = Yaks.yaks_config.runner(object, {env: env}.merge(opts))
       content_type runner.format_name
-      runner.result
+      runner.call
     end
   end
 


### PR DESCRIPTION
yaks-sinatra is broken since v0.7.7 due to the removal of the result alias in 163ee68acf