### PR TITLE
JSON-API: 'included' and 'linkage'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,18 @@
 ### master
 [full changelog](http://github.com/plexus/yaks/compare/v0.9.0...master)
 
-### v0.9.0
-
-Make dynamic form fields respect the order in which they were declared
-in the form relative to other form fields.
+Updated JSON-API Reader to handle collections
 
 Further changes to bring JSONAPI formatting more in line with 1.0 format
 
 - Changed `linked` to `included`
 - Change format of `links` to include 'linkages'
+- `included` no longer contains duplicates
+
+### v0.9.0
+
+Make dynamic form fields respect the order in which they were declared
+in the form relative to other form fields.
 
 Some changes to bring JSONAPI formatting more in line with 1.0 format
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@
 Make dynamic form fields respect the order in which they were declared
 in the form relative to other form fields.
 
+Further changes to bring JSONAPI formatting more in line with 1.0 format
+
+- Changed `linked` to `included`
+- Change format of `links` to include 'linkages'
+
 Some changes to bring JSONAPI formatting more in line with 1.0 format
+
  - Top level key must be named 'data' rather than the resource type
  - The resource name myst be included in a 'type' attribute
 

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -9,8 +9,8 @@ module Yaks
       # @return [Hash]
       def call(resource, _env = nil)
         main_collection = resource.seq.map(&method(:serialize_resource))
-
-        { data: main_collection }.tap do |serialized|
+        output = resource.attributes.select{|k| k.equal?(:meta)}
+        output.merge({ data: main_collection }).tap do |serialized|
           included = resource.seq.each_with_object([]) do |res, array|
             serialize_included_subresources(res.subresources, array)
           end

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -38,7 +38,7 @@ module Yaks
       def serialize_links(subresources)
         subresources.each_with_object({}) do |resource, hsh|
           next if resource.null_resource?
-          hsh[resource.rels.first] = serialize_link(resource)
+          hsh[resource.rels.first.sub(/^rel:/, '')] = serialize_link(resource)
         end
       end
 

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -76,7 +76,9 @@ module Yaks
       # @param [Hash] included
       # @return [Hash]
       def serialize_subresource(resource, included)
-        included << serialize_resource(resource)
+        included << serialize_resource(resource) unless included.any? do |item|
+          item[:id].equal?(resource[:id]) && item[:type].equal?(pluralize(resource.type).to_sym)
+        end
         serialize_included_subresources(resource.subresources, included)
       end
 

--- a/yaks/lib/yaks/reader/json_api.rb
+++ b/yaks/lib/yaks/reader/json_api.rb
@@ -6,6 +6,7 @@ module Yaks
 
         if parsed_json['data'].is_a?(Array)
           CollectionResource.new(
+              attributes: parsed_json['meta'].nil? ? nil : {meta: parsed_json['meta']},
               members: parsed_json['data'].map { |data| call({'data'  => data, 'included' => included}) }
           )
         else

--- a/yaks/lib/yaks/reader/json_api.rb
+++ b/yaks/lib/yaks/reader/json_api.rb
@@ -4,8 +4,8 @@ module Yaks
       def call(parsed_json, env = {})
         attributes = parsed_json['data'].first.dup
         links = attributes.delete('links') || {}
-        linked = parsed_json['linked'].nil? ? {} : parsed_json['linked'].dup
-        embedded   = convert_embedded(links, linked)
+        included = parsed_json['included'].nil? ? {} : parsed_json['included'].dup
+        embedded   = convert_embedded(links, included)
         Resource.new(
             type: Util.singularize(attributes.delete('type')[/\w+$/]),
             attributes: Util.symbolize_keys(attributes),
@@ -14,36 +14,34 @@ module Yaks
         )
       end
 
-      def convert_embedded(links, linked)
+      def convert_embedded(links, included)
         links.flat_map do |rel, link_data|
-          # If this is a compound link, the link_data will contain either
-          # * 'type' and 'id' for a one to one
-          # * 'type' and 'ids' for a homogeneous to-many relationship
-          # * 'data' being an array where each member has 'type' and 'id' for heterogeneous
-          if !link_data['type'].nil? && !link_data['id'].nil?
-            resource = linked.find{ |item| (item['id'] == link_data['id']) && (item['type'] == link_data['type']) }
-            call({'data'  => [resource], 'linked' => linked}).with(rels: [rel])
-          elsif !link_data['type'].nil? && !link_data['ids'].nil?
-            resources = linked.select{ |item| (link_data['ids'].include? item['id']) && (item['type'] == link_data['type']) }
-            members = resources.map { |r|
-              call({'data'  => [r], 'linked' => linked})
-            }
+          # A Link doesn't have to contain a `linkage` member.
+          # It can contain URLs instead, or as well, but we are only worried about *embedded* links here.
+          linkage = link_data['linkage']
+          # Resource linkage MUST be represented as one of the following:
+          #
+          # * `null` for empty to-one relationships.
+          # * a "linkage object" for non-empty to-one relationships.
+          # * an empty array ([]) for empty to-many relationships.
+          # * an array of linkage objects for non-empty to-many relationships.
+          if linkage.nil?
+            nil
+          elsif linkage.is_a? Array
             CollectionResource.new(
-                members: members,
-                type: link_data['type'],
-                rels: [rel]
-            )
-          elsif link_data['data'].present?
-            CollectionResource.new(
-                members: link_data['data'].map { |link|
-                  resource = linked.find{ |item| (item['id'] == link['id']) && (item['type'] == link['type']) }
-                  call({'data'  => [resource], 'linked' => linked})
+                members: linkage.map { |link|
+                  data = included.find{ |item| (item['id'] == link['id']) && (item['type'] == link['type']) }
+                  call({'data'  => [data], 'included' => included})
                 },
                 rels: [rel]
             )
+          else
+            data = included.find{ |item| (item['id'] == linkage['id']) && (item['type'] == linkage['type']) }
+            call({'data'  => [data], 'included' => included}).with(rels: [rel])
           end
         end.compact
       end
+
     end
   end
 end

--- a/yaks/spec/json/confucius.json_api.json
+++ b/yaks/spec/json/confucius.json_api.json
@@ -1,4 +1,11 @@
 {
+  "meta": {
+    "page": {
+      "limit": 10,
+      "offset": 0,
+      "total": 2
+    }
+  },
   "data": [
     {
       "id": 9,

--- a/yaks/spec/json/confucius.json_api.json
+++ b/yaks/spec/json/confucius.json_api.json
@@ -8,13 +8,24 @@
       "pinyin": "Kongzi",
       "latinized": "Confucius",
       "links": {
-        "works": {"linkage": [{"type": "works", "id": 11}, {"type": "works", "id": 12}]}
+        "works": {"linkage": [{"type": "works", "id": 17}, {"type": "works", "id": 12}]}
+      }
+    },
+    {
+      "id": 7,
+      "type": "scholars",
+      "href": "http://literature.example.com/authors/tolkein",
+      "name": "JRR",
+      "pinyin": "Joey",
+      "latinized": "Jorge",
+      "links": {
+        "works": {"linkage": [{"type": "works", "id": 17}]}
       }
     }
   ],
   "included": [
       {
-        "id": 11,
+        "id": 17,
         "type": "works",
         "href": "http://literature.example.com/work/11",
         "chinese_name": "論語",

--- a/yaks/spec/json/confucius.json_api.json
+++ b/yaks/spec/json/confucius.json_api.json
@@ -8,11 +8,11 @@
       "pinyin": "Kongzi",
       "latinized": "Confucius",
       "links": {
-        "works": {"type": "works", "ids": [11,12]}
+        "works": {"linkage": [{"type": "works", "id": 11}, {"type": "works", "id": 12}]}
       }
     }
   ],
-  "linked": [
+  "included": [
       {
         "id": 11,
         "type": "works",
@@ -20,8 +20,8 @@
         "chinese_name": "論語",
         "english_name": "Analects",
         "links": {
-          "quotes": {"type": "quotes", "ids": [17, 18]},
-          "era": {"type": "erae", "id": 99}
+          "quotes": {"linkage": [{"type": "quotes", "id": 17}, {"type": "quotes", "id": 18}]},
+          "era": {"linkage": {"type": "erae", "id": 99}}
         }
       },
       {

--- a/yaks/spec/unit/yaks/config_spec.rb
+++ b/yaks/spec/unit/yaks/config_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Yaks::Config do
       expect(config.read('{"data": [{"type": "pets",
                                      "id": 3,
                                      "name": "wassup",
-                                     "species": "cat"}]}'))
+                                     "species": "cat"}]}').members.first)
         .to eql Yaks::Resource.new(
                   type: "pet",
                   attributes: {:id=>3, :name=>"wassup", :species=>"cat"}

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Yaks::Format::JsonAPI do
   context 'with no subresources' do
     let(:resource) { Yaks::Resource.new(type: 'wizard', attributes: {foo: :bar}) }
 
-    it 'should not include a "linked" key' do
+    it 'should not include an "included" key' do
       expect(format.call(resource)).to eql(
         {data: [{type: :wizards, foo: :bar}]}
       )
@@ -67,20 +67,20 @@ RSpec.describe Yaks::Format::JsonAPI do
       Yaks::Resource.new(
           type: 'wizard',
           subresources: [
-              Yaks::Resource.new(type: 'spell', attributes: {id: 777, name: 'Lucky Sevens'})
+              Yaks::Resource.new(rels: ['favourite_spell'], type: 'spell', attributes: {id: 777, name: 'Lucky Sevens'})
           ]
       )
     }
-    it 'should include links and linked' do
+    it 'should include links and included' do
       expect(format.call(resource)).to eql(
          {
            data: [
              {
                type: :wizards,
-               links: {'spell'  => {type: 'spells', id: 777}}
+               links: {'favourite_spell'  => {linkage: {type: 'spells', id: 777}}}
              }
            ],
-           linked: [{type: :spells, id: 777, name: 'Lucky Sevens'}]
+           included: [{type: :spells, id: 777, name: 'Lucky Sevens'}]
          }
       )
     end

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Yaks::Format::JsonAPI do
       Yaks::Resource.new(
           type: 'wizard',
           subresources: [
-              Yaks::Resource.new(rels: ['favourite_spell'], type: 'spell', attributes: {id: 777, name: 'Lucky Sevens'})
+              Yaks::Resource.new(rels: ['rel:favourite_spell'], type: 'spell', attributes: {id: 777, name: 'Lucky Sevens'})
           ]
       )
     }

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -12,6 +12,24 @@ RSpec.describe Yaks::Format::JsonAPI do
     end
   end
 
+  context 'collection with metadata' do
+    let(:resource) { Yaks::CollectionResource.new(
+        type: 'wizard',
+        members: [Yaks::Resource.new(type: 'wizard', attributes: {foo: :bar})],
+        attributes: {meta: {page: {limit: 20, offset: 0, count: 25}}}
+    ) }
+
+    it 'should include the "meta" key' do
+      expect(format.call(resource)).to eql(
+        {
+          meta: {page: {limit: 20, offset: 0, count: 25}},
+          data: [{type: :wizards, foo: :bar}]
+        }
+      )
+
+    end
+  end
+
   context 'with both a "href" attribute and a self link' do
     let(:resource) {
       Yaks::Resource.new(


### PR DESCRIPTION
Further changes to bring JSONAPI formatting more in line with 1.0 format

- Changed `linked` to `included`
- Change format of `links` to include 'linkages'