### PR TITLE
Mapper .attribute method now accepts a block

### DIFF
--- a/yaks/README.md
+++ b/yaks/README.md
@@ -149,7 +149,7 @@ yaks.call(post, mapper: PostMapper, format: :hal)
 
 ### Attributes
 
-Use the `attributes` DSL method to specify which attributes of your model you want to expose, as in the example above. You can override the `load_attribute` method to change how attributes are fetched from the model.
+Use the `attribute` or `attributes` DSL methods to specify which attributes of your model you want to expose, as in the example above. You can override the `load_attribute` method to change how attributes are fetched from the model.
 
 For example, if you are representing data that is stored in a Hash, you could do
 
@@ -163,12 +163,14 @@ class PostHashMapper < Yaks::Mapper
   end
 end
 ```
-
-The default implementation will first try to find a matching method for an attribute on the mapper itself, and will then fall back to calling the actual model. So you can add extra 'virtual' attributes like so :
+The `.attribute` method may also take a block that will be called with the context of the mapper instance. The default implementation will use the block if provided, otherwise it will first try to find a matching method for an attribute on the mapper itself, and will then fall back to calling the actual model. So you can add extra 'virtual' attributes like so :
 
 ```ruby
 class CommentMapper < Yaks::Mapper
-  attributes :id, :body, :date
+  attributes :body, :date
+  attribute :id do
+    "Id-#{object.id}"
+  end
 
   def date
     object.created_at.strftime("at %I:%M%p")

--- a/yaks/lib/yaks/mapper/attribute.rb
+++ b/yaks/lib/yaks/mapper/attribute.rb
@@ -1,14 +1,20 @@
 module Yaks
   class Mapper
     class Attribute
-      include Attribs.new(:name)
+      include Attribs.new(:name, :block)
+      include Util
 
-      def initialize(name)
-        super(name: name)
+      def self.create(name, _options = nil, &block)
+        new({ name: name, block: block })
       end
 
       def add_to_resource(resource, mapper, _context)
-        resource.merge_attributes(name => mapper.load_attribute(name))
+        if block
+          attribute = Resolve(block, mapper)
+        else
+          attribute = mapper.load_attribute(name)
+        end
+        resource.merge_attributes(name => attribute)
       end
     end
   end

--- a/yaks/lib/yaks/mapper/config.rb
+++ b/yaks/lib/yaks/mapper/config.rb
@@ -6,7 +6,7 @@ module Yaks
               )
 
       def add_attributes(*attrs)
-        append_to(:attributes, *attrs.map(&Attribute.method(:new)))
+        append_to(:attributes, *attrs.map(&Attribute.method(:create)))
       end
     end
   end

--- a/yaks/spec/unit/yaks/mapper/attribute_spec.rb
+++ b/yaks/spec/unit/yaks/mapper/attribute_spec.rb
@@ -1,21 +1,57 @@
 RSpec.describe Yaks::Mapper::Attribute do
   include_context 'yaks context'
 
-  subject(:attribute) { described_class.new(:the_name) }
+  let(:attribute_with_block) { described_class.create(:the_name) { "Alice" } }
+
+  subject(:attribute) { described_class.create(:the_name) }
   fake(:mapper)
 
   before do
     stub(mapper).load_attribute(:the_name) { 123 }
+    stub(mapper).object { fake(name: "Bob") }
   end
 
-  describe "#initialize" do
+  describe ".create" do
     its(:name) { should be :the_name }
+    its(:block) { should be_nil }
+
+    it "should accept two parameter" do
+      expect{described_class.create(:the_name, {})}.not_to raise_error()
+    end
+
+    context "with block" do
+      subject(:attribute) { attribute_with_block }
+
+      its(:block) { should_not be_nil }
+
+      it "should store the given block" do
+        expect(subject.block.call).to eq("Alice")
+      end
+    end
   end
 
   describe "#add_to_resource" do
     it "should add itself to a resource based on a lookup" do
       expect(attribute.add_to_resource(Yaks::Resource.new, mapper , yaks_context))
         .to eql(Yaks::Resource.new(attributes: { :the_name => 123 }))
+    end
+
+    context "when the attribute has a block" do
+      subject(:attribute) { attribute_with_block }
+
+      it "should add itself to a resource with the block value" do
+        expect(attribute.add_to_resource(Yaks::Resource.new, mapper , yaks_context))
+          .to eql(Yaks::Resource.new(attributes: { :the_name => "Alice" }))
+      end
+
+      context "using the mapper context" do
+        let(:attribute) { described_class.create(:the_name) { object.name } }
+
+        it "should add itself to a resource with the block value" do
+          expect(attribute.add_to_resource(Yaks::Resource.new, mapper , yaks_context))
+            .to eql(Yaks::Resource.new(attributes: { :the_name => "Bob" }))
+        end
+      end
     end
   end
 end

--- a/yaks/spec/unit/yaks/mapper/config_spec.rb
+++ b/yaks/spec/unit/yaks/mapper/config_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Yaks::Mapper::Config do
     it 'should add attributes' do
       expect(subject.add_attributes(:bar).add_attributes(:baz)).to eql described_class.new(
         attributes: [
-          Yaks::Mapper::Attribute.new(:bar),
-          Yaks::Mapper::Attribute.new(:baz),
+          Yaks::Mapper::Attribute.create(:bar),
+          Yaks::Mapper::Attribute.create(:baz),
         ]
       )
     end


### PR DESCRIPTION
Mapper can now define attributes using a block, e.g.:

```ruby
def PostMapper < Yaks::Mapper
  attribute :full_name do
    "#{object.first_name} #{object.last_name}"
  end
end
```

Resolves #15.