### PR TITLE
Make Yaks warnings-clean

### DIFF
--- a/yaks/lib/yaks.rb
+++ b/yaks/lib/yaks.rb
@@ -44,9 +44,9 @@ module Yaks
   ]
 
   ConfigBuilder = Builder.new(Yaks::Config) do
-    def_set *Yaks::Config.attributes.names
-    def_forward *DSL_METHODS
-    def_forward *Yaks::DefaultPolicy.public_instance_methods(false)
+    def_set(*Yaks::Config.attributes.names)
+    def_forward(*DSL_METHODS)
+    def_forward(*Yaks::DefaultPolicy.public_instance_methods(false))
   end
 
   class << self

--- a/yaks/lib/yaks/builder.rb
+++ b/yaks/lib/yaks/builder.rb
@@ -22,7 +22,7 @@ module Yaks
     def initialize(klass, methods = [], &block)
       @klass = klass
       @methods = methods
-      def_forward *methods if methods.any?
+      def_forward(*methods) if methods.any?
       instance_eval(&block) if block
     end
 

--- a/yaks/lib/yaks/configurable.rb
+++ b/yaks/lib/yaks/configurable.rb
@@ -54,7 +54,7 @@ module Yaks
     #
     # Either takes a list of methods to forward, or a mapping (hash)
     # of source to destination method name.
-    def def_forward(mappings, *args)
+    def def_forward(mappings, *names)
       if mappings.instance_of? Hash
         mappings.each do |method_name, target|
           define_singleton_method method_name do |*args, &block|
@@ -62,7 +62,7 @@ module Yaks
           end
         end
       else
-        def_forward([mappings, *args].map{|name| {name => name}}.inject(:merge))
+        def_forward([mappings, *names].map{|name| {name => name}}.inject(:merge))
       end
     end
 

--- a/yaks/lib/yaks/configurable.rb
+++ b/yaks/lib/yaks/configurable.rb
@@ -74,6 +74,7 @@ module Yaks
     # This will generate a `fieldset` method, which will call
     # `Fieldset.create`, and append the result to `config.fields`
     def def_add(name, options)
+      old_verbose, $VERBOSE = $VERBOSE, false # skip method redefinition warning
       define_singleton_method name do |*args, &block|
         defaults = options.fetch(:defaults, {})
         klass    = options.fetch(:create)
@@ -89,6 +90,8 @@ module Yaks
           klass.create(*args, &block)
         )
       end
+    ensure
+      $VERBOSE = old_verbose
     end
 
   end

--- a/yaks/lib/yaks/mapper/has_many.rb
+++ b/yaks/lib/yaks/mapper/has_many.rb
@@ -12,6 +12,7 @@ module Yaks
         collection_mapper(collection, policy).new(context).call(collection)
       end
 
+      undef collection_mapper
       def collection_mapper(collection = nil, policy = nil)
         return @collection_mapper unless @collection_mapper.equal? Undefined
         policy.derive_mapper_from_object(collection) if policy && collection

--- a/yaks/lib/yaks/resource/form/field.rb
+++ b/yaks/lib/yaks/resource/form/field.rb
@@ -4,6 +4,7 @@ module Yaks
       class Field
         include Yaks::Mapper::Form::Field.attributes.add(:error => nil)
 
+        undef value
         def value
           if type.equal? :select
             selected = options.find(&:selected)


### PR DESCRIPTION
This makes Yaks warnings-clean and fixes #70.

I am really unhappy about the fix for `Configurable#def_add`, but I couldn’t come up with a better solution. Not defining the method if `singleton_methods.include?(name)` breaks the build. :(