### PR TITLE
Give Enumerables CollectionMapper

### DIFF
--- a/yaks/lib/yaks/default_policy.rb
+++ b/yaks/lib/yaks/default_policy.rb
@@ -22,7 +22,7 @@ module Yaks
     #
     # @raise [NameError] only occurs when the model is anything but a collection.
     def derive_mapper_from_object(model)
-      if model.respond_to? :to_ary
+      if Enumerable === model
         if m = model.first
           name = m.class.name.split('::').last + 'CollectionMapper'
           begin

--- a/yaks/spec/unit/yaks/default_policy/derive_mapper_from_object_spec.rb
+++ b/yaks/spec/unit/yaks/default_policy/derive_mapper_from_object_spec.rb
@@ -17,10 +17,24 @@ RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_object' do
     end
   end
 
-  context 'for array-like objects' do
+  context 'for enumerable objects' do
     context 'given an empty array' do
       it 'should return the vanilla CollectionMapper' do
         expect(policy.derive_mapper_from_object([])).to be Yaks::CollectionMapper
+      end
+    end
+
+    context 'given an Enumerable' do
+      let(:enumerable_class) do
+        Class.new do
+          include Enumerable
+          def each(*); end
+        end
+      end
+      let(:collection) { enumerable_class.new }
+
+      it 'should return the vanilla CollectionMapper' do
+        expect(policy.derive_mapper_from_object(collection)).to be Yaks::CollectionMapper
       end
     end
 


### PR DESCRIPTION
In Ruby it's considered a collection anything that is Enumerable, so it would be great to see this in Yaks. This way Yaks would by default recognize ActiveRecord::Relations and Sequel::Datasets.

By the way, I'm really damn impressed with Yaks, I only found out about it couple of days ago. I'm not using Rails nor ActiveRecord, so ActiveModel::Serializers are out of the picture. And I was thinking of making a gem similar to it, but generic for any serialization (I'm irritated that ActiveModel::Serializers is ActiveModel-specific, it could easily have been generic). Then I saw Yaks, I was happy that someone already did it. When I saw `drive_mapper_from_object`, and how it was designed to be overriden, that was exactly how I wanted to do it. Great job!