### PR TITLE
Fix singular resources for JSON API

### DIFF
--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -8,9 +8,10 @@ module Yaks
       # @param [Yaks::Resource] resource
       # @return [Hash]
       def call(resource, _env = nil)
-        main_collection = resource.seq.map(&method(:serialize_resource))
+        main_object = resource.seq.map(&method(:serialize_resource))
+        main_object = main_object.first unless resource.collection?
         output = resource.attributes.select{|k| k.equal?(:meta)}
-        output.merge({ data: main_collection }).tap do |serialized|
+        output.merge({ data: main_object }).tap do |serialized|
           included = resource.seq.each_with_object([]) do |res, array|
             serialize_included_subresources(res.subresources, array)
           end

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Yaks::Format::JsonAPI do
 
     it 'should not include an "included" key' do
       expect(format.call(resource)).to eql(
-        {data: [{type: :wizards, foo: :bar}]}
+        {data: {type: :wizards, foo: :bar}}
       )
     end
   end
@@ -26,7 +26,6 @@ RSpec.describe Yaks::Format::JsonAPI do
           data: [{type: :wizards, foo: :bar}]
         }
       )
-
     end
   end
 
@@ -46,12 +45,8 @@ RSpec.describe Yaks::Format::JsonAPI do
     # TODO should it really behave this way? better to give preference to self link.
     it 'should give preference to the href attribute' do
       expect(format.call(resource)).to eql(
-        {data: [
-            {
-              type: :wizards,
-              href: '/the/href'
-            }
-          ]
+        {
+          data: {type: :wizards, href: '/the/href'}
         }
       )
     end
@@ -68,12 +63,8 @@ RSpec.describe Yaks::Format::JsonAPI do
     }
     it 'should use the self link in output' do
       expect(format.call(resource)).to eql(
-         {data: [
-             {
-                 type: :wizards,
-                 href: '/the/self/link'
-             }
-         ]
+         {
+           data: {type: :wizards, href: '/the/self/link'}
          }
       )
 
@@ -92,12 +83,10 @@ RSpec.describe Yaks::Format::JsonAPI do
     it 'should include links and included' do
       expect(format.call(resource)).to eql(
          {
-           data: [
-             {
-               type: :wizards,
-               links: {'favourite_spell'  => {linkage: {type: 'spells', id: 777}}}
-             }
-           ],
+           data: {
+             type: :wizards,
+             links: {'favourite_spell'  => {linkage: {type: 'spells', id: 777}}}
+           },
            included: [{type: :spells, id: 777, name: 'Lucky Sevens'}]
          }
       )
@@ -116,11 +105,8 @@ RSpec.describe Yaks::Format::JsonAPI do
     }
     it 'should not include links' do
       expect(format.call(resource)).to eql(
-         {data: [
-             {
-                 type: :wizards,
-             }
-         ]
+         {
+           data: {type: :wizards}
          }
       )
     end
@@ -135,11 +121,8 @@ RSpec.describe Yaks::Format::JsonAPI do
     }
     it 'should not include links' do
       expect(format.call(resource)).to eql(
-         {data: [
-             {
-                 type: :wizards
-             }
-         ]
+         {
+           data: {type: :wizards}
          }
       )
     end


### PR DESCRIPTION
Maybe before all resources were shown as an array, but now the JSON API documentation states that singular resources should be returned as a hash instead of an array:

```json
{
  "data": {
    "type": "articles",
    "title": "Singular"
  }
}
```

You can see that e.g. in [Top level](http://jsonapi.org/format/#document-structure-top-level). Since JSON API is in RC3 now, we can safely assume this isn't going to change before 1.0.