### PR TITLE
Display top level links for JSON API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -135,3 +135,6 @@ Style/StringLiterals:
 Style/UnneededPercentQ:
   Exclude:
     - yaks/lib/yaks/breaking_changes.rb
+
+Style/TrailingComma:
+  Enabled: false

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -11,6 +11,7 @@ module Yaks
         output = {}
         if resource.collection?
           output[:data]  = resource.map(&method(:serialize_resource))
+          output[:links] = serialize_links(resource.links) if resource.links.any?
         else
           output[:data] = serialize_resource(resource)
         end
@@ -20,6 +21,14 @@ module Yaks
         output[:included] = included if included.any?
         output[:meta] = resource[:meta] if resource[:meta]
         output
+      end
+
+      # @param [Yaks::Resource] resource
+      # @return [Hash]
+      def serialize_links(links)
+        links.inject({}) do |hash, link|
+          hash.update(link.rel => link.uri)
+        end
       end
 
       # @param [Yaks::Resource] resource

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -8,15 +8,18 @@ module Yaks
       # @param [Yaks::Resource] resource
       # @return [Hash]
       def call(resource, _env = nil)
-        main_object = resource.seq.map(&method(:serialize_resource))
-        main_object = main_object.first unless resource.collection?
-        output = resource.attributes.select{|k| k.equal?(:meta)}
-        output.merge(data: main_object).tap do |serialized|
-          included = resource.seq.each_with_object([]) do |res, array|
-            serialize_included_subresources(res.subresources, array)
-          end
-          serialized.merge!(included: included) unless included.empty?
+        output = {}
+        if resource.collection?
+          output[:data]  = resource.map(&method(:serialize_resource))
+        else
+          output[:data] = serialize_resource(resource)
         end
+        included = resource.seq.each_with_object([]) do |res, array|
+          serialize_included_subresources(res.subresources, array)
+        end
+        output[:included] = included if included.any?
+        output[:meta] = resource[:meta] if resource[:meta]
+        output
       end
 
       # @param [Yaks::Resource] resource
@@ -24,7 +27,7 @@ module Yaks
       def serialize_resource(resource)
         result = {type: pluralize(resource.type).to_sym}.merge(resource.attributes)
 
-        links = serialize_links(resource.subresources)
+        links = serialize_subresource_links(resource.subresources)
         result[:links] = links unless links.empty?
 
         if resource.self_link && !result.key?(:href)
@@ -36,16 +39,16 @@ module Yaks
 
       # @param [Yaks::Resource] subresource
       # @return [Hash]
-      def serialize_links(subresources)
+      def serialize_subresource_links(subresources)
         subresources.each_with_object({}) do |resource, hsh|
           next if resource.null_resource?
-          hsh[resource.rels.first.sub(/^rel:/, '')] = serialize_link(resource)
+          hsh[resource.rels.first.sub(/^rel:/, '')] = serialize_subresource_link(resource)
         end
       end
 
       # @param [Yaks::Resource] resource
       # @return [Array, String]
-      def serialize_link(resource)
+      def serialize_subresource_link(resource)
         if resource.collection?
           {linkage: resource.map{|r| {type: pluralize(r.type), id: r[:id]} }}
         else

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Yaks::Format::JsonAPI do
         type: 'wizard',
         members: [Yaks::Resource.new(type: 'wizard', attributes: {foo: :bar})],
         attributes: {meta: {page: {limit: 20, offset: 0, count: 25}}}
-    )
+      )
     }
 
     it 'should include the "meta" key' do
@@ -59,6 +59,7 @@ RSpec.describe Yaks::Format::JsonAPI do
         ]
       )
     }
+
     it 'should use the self link in output' do
       expect(format.call(resource)).to eql(
         data: {type: :wizards, href: '/the/self/link'}
@@ -75,7 +76,8 @@ RSpec.describe Yaks::Format::JsonAPI do
         ]
       )
     }
-    it 'should include links and included' do
+
+    it 'should include subresource links and included' do
       expect(format.call(resource)).to eql(
         data: {
           type: :wizards,
@@ -90,26 +92,26 @@ RSpec.describe Yaks::Format::JsonAPI do
     let(:resource) {
       Yaks::Resource.new(
         type: 'wizard',
-        subresources: [
-          Yaks::NullResource.new
-        ]
+        subresources: [Yaks::NullResource.new]
       )
     }
-    it 'should not include links' do
+
+    it 'should not include subresource links' do
       expect(format.call(resource)).to eql(
         data: {type: :wizards}
       )
     end
   end
 
-  context 'with no subresources or links' do
+  context 'with no subresources or subresource links' do
     let(:resource) {
       Yaks::Resource.new(
         type: 'wizard',
         subresources: []
       )
     }
-    it 'should not include links' do
+
+    it 'should not include subresource links' do
       expect(format.call(resource)).to eql(
         data: {type: :wizards}
       )

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -117,4 +117,26 @@ RSpec.describe Yaks::Format::JsonAPI do
       )
     end
   end
+
+  context 'with links as collection' do
+    let(:resource) {
+      Yaks::CollectionResource.new(
+        type: 'wizard',
+        links: [
+          Yaks::Resource::Link.new(rel: :prev, uri: '/prev/page/link'),
+          Yaks::Resource::Link.new(rel: :next, uri: '/next/page/link'),
+        ]
+      )
+    }
+
+    it 'should include links' do
+      expect(format.call(resource)).to eql(
+        data: [],
+        links: {
+          prev: '/prev/page/link',
+          next: '/next/page/link',
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
Currently, if you have

```rb
class CollectionMapper < Yaks::CollectionMapper
  link :next, '/link/to/next/page'
end
```

the "next" link won't be displayed anywhere. So I added it to be displayed according to the spec:

```json
{
  "links": {
    "next": "/link/to/next/page"
  },
  "data": [
    {"type": "..."},
    {"type": "..."}
  ]
}
```