### PR TITLE
yaks-html: disable a false RuboCop offence until Hexp::Node#find exists

### DIFF
--- a/yaks-html/lib/yaks/format/html.rb
+++ b/yaks-html/lib/yaks/format/html.rb
@@ -12,7 +12,7 @@ module Yaks
       end
 
       def section(name)
-        template.find(".#{name}")
+        template.select(".#{name}").first   # rubocop:disable Performance/Detect
       end
 
       def serialize_resource(resource)


### PR DESCRIPTION
I turns out <del>yaks-html is missing specs</del> [I was over-zealous](https://github.com/plexus/yaks/commit/8317d26cabf5bd3788bf8c93ba4f297f64f17268#commitcomment-11063294) when fixing RuboCop offences.