### PR TITLE
More JSON-API updates

### DIFF
--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -38,7 +38,7 @@ module Yaks
       def serialize_resource(resource)
         result = {}
         result[:type] = pluralize(resource.type).to_sym
-        result[:id]   = resource[:id] if resource[:id]
+        result[:id]   = resource[:id].to_s if resource[:id]
 
         attributes = resource.attributes.reject { |k, _| k == :id }
         result[:attributes] = attributes if attributes.any?
@@ -64,9 +64,9 @@ module Yaks
       # @return [Array, String]
       def serialize_subresource_link(resource)
         if resource.collection?
-          {linkage: resource.map{|r| {type: pluralize(r.type), id: r[:id]} }}
+          {linkage: resource.map{|r| {type: pluralize(r.type), id: r[:id].to_s} }}
         else
-          {linkage: {type: pluralize(resource.type), id: resource[:id]}}
+          {linkage: {type: pluralize(resource.type), id: resource[:id].to_s}}
         end
       end
 

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -20,6 +20,7 @@ module Yaks
         end
         output[:included] = included if included.any?
         output[:meta] = resource[:meta] if resource[:meta]
+
         output
       end
 
@@ -27,7 +28,8 @@ module Yaks
       # @return [Hash]
       def serialize_links(links)
         links.inject({}) do |hash, link|
-          hash.update(link.rel => link.uri)
+          hash[link.rel] = link.uri
+          hash
         end
       end
 
@@ -36,12 +38,10 @@ module Yaks
       def serialize_resource(resource)
         result = {type: pluralize(resource.type).to_sym}.merge(resource.attributes)
 
-        links = serialize_subresource_links(resource.subresources)
-        result[:links] = links unless links.empty?
-
-        if resource.self_link && !result.key?(:href)
-          result[:href]  = resource.self_link.uri
-        end
+        result[:links] = {}
+        result[:links].update(serialize_subresource_links(resource.subresources))
+        result[:links].update(serialize_links(resource.links))
+        result.delete(:links) if result[:links].empty?
 
         result
       end

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -36,7 +36,7 @@ module Yaks
       # @return [Hash]
       def serialize_resource(resource)
         result = {}
-        result[:type] = pluralize(resource.type).to_sym
+        result[:type] = pluralize(resource.type)
         result[:id]   = resource[:id].to_s if resource[:id]
 
         attributes = resource.attributes.reject { |k| k.equal?(:id) }
@@ -94,7 +94,7 @@ module Yaks
       # @return [Hash]
       def serialize_subresource(resource, included)
         included << serialize_resource(resource) unless included.any? do |item|
-          item[:id].eql?(resource[:id].to_s) && item[:type].equal?(pluralize(resource.type).to_sym)
+          item[:id].eql?(resource[:id].to_s) && item[:type].eql?(pluralize(resource.type))
         end
         serialize_included_subresources(resource.subresources, included)
       end

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -27,9 +27,8 @@ module Yaks
       # @param [Yaks::Resource] resource
       # @return [Hash]
       def serialize_links(links)
-        links.inject({}) do |hash, link|
+        links.each_with_object({}) do |link, hash|
           hash[link.rel] = link.uri
-          hash
         end
       end
 
@@ -40,7 +39,7 @@ module Yaks
         result[:type] = pluralize(resource.type).to_sym
         result[:id]   = resource[:id].to_s if resource[:id]
 
-        attributes = resource.attributes.reject { |k, _| k == :id }
+        attributes = resource.attributes.reject { |k| k.equal?(:id) }
         result[:attributes] = attributes if attributes.any?
 
         result[:links] = {}
@@ -88,14 +87,14 @@ module Yaks
         end
       end
 
-      # {shows => [{id: 3, name: 'foo'}]}
+      # {shows => [{id: '3', name: 'foo'}]}
       #
       # @param [Yaks::Resource] resource
       # @param [Hash] included
       # @return [Hash]
       def serialize_subresource(resource, included)
         included << serialize_resource(resource) unless included.any? do |item|
-          item[:id].equal?(resource[:id]) && item[:type].equal?(pluralize(resource.type).to_sym)
+          item[:id].eql?(resource[:id].to_s) && item[:type].equal?(pluralize(resource.type).to_sym)
         end
         serialize_included_subresources(resource.subresources, included)
       end

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -36,7 +36,12 @@ module Yaks
       # @param [Yaks::Resource] resource
       # @return [Hash]
       def serialize_resource(resource)
-        result = {type: pluralize(resource.type).to_sym}.merge(resource.attributes)
+        result = {}
+        result[:type] = pluralize(resource.type).to_sym
+        result[:id]   = resource[:id] if resource[:id]
+
+        attributes = resource.attributes.reject { |k, _| k == :id }
+        result[:attributes] = attributes if attributes.any?
 
         result[:links] = {}
         result[:links].update(serialize_subresource_links(resource.subresources))

--- a/yaks/lib/yaks/reader/json_api.rb
+++ b/yaks/lib/yaks/reader/json_api.rb
@@ -15,7 +15,7 @@ module Yaks
           type  = attributes.delete('type')
           attributes.merge!(attributes.delete('attributes') || {})
 
-          association_links, resource_links = links.partition { |k, v| v.is_a?(Hash) }
+          association_links, resource_links = links.partition { |_k, v| v.is_a?(Hash) }
           embedded   = convert_embedded(Hash[association_links], included)
           links      = convert_links(Hash[resource_links])
 

--- a/yaks/lib/yaks/reader/json_api.rb
+++ b/yaks/lib/yaks/reader/json_api.rb
@@ -12,12 +12,15 @@ module Yaks
         else
           attributes = parsed_json['data'].dup
           links = attributes.delete('links') || {}
-          embedded   = convert_embedded(links, included)
+          association_links, resource_links = links.partition { |k, v| v.is_a?(Hash) }
+          embedded   = convert_embedded(Hash[association_links], included)
+          links      = convert_links(Hash[resource_links])
+
           Resource.new(
             type: Util.singularize(attributes.delete('type')[/\w+$/]),
             attributes: Util.symbolize_keys(attributes),
             subresources: embedded,
-            links: []
+            links: links
           )
         end
       end
@@ -48,6 +51,12 @@ module Yaks
             call('data'  => data, 'included' => included).with(rels: [rel])
           end
         end.compact
+      end
+
+      def convert_links(links)
+        links.map do |rel, link|
+          Resource::Link.new(rel: rel.to_sym, uri: link)
+        end
       end
     end
   end

--- a/yaks/lib/yaks/reader/json_api.rb
+++ b/yaks/lib/yaks/reader/json_api.rb
@@ -12,12 +12,15 @@ module Yaks
         else
           attributes = parsed_json['data'].dup
           links = attributes.delete('links') || {}
+          type  = attributes.delete('type')
+          attributes.merge!(attributes.delete('attributes') || {})
+
           association_links, resource_links = links.partition { |k, v| v.is_a?(Hash) }
           embedded   = convert_embedded(Hash[association_links], included)
           links      = convert_links(Hash[resource_links])
 
           Resource.new(
-            type: Util.singularize(attributes.delete('type')[/\w+$/]),
+            type: Util.singularize(type),
             attributes: Util.symbolize_keys(attributes),
             subresources: embedded,
             links: links

--- a/yaks/spec/json/confucius.json_api.json
+++ b/yaks/spec/json/confucius.json_api.json
@@ -2,11 +2,13 @@
   "data": {
     "id": 9,
     "type": "scholars",
-    "href": "http://literature.example.com/authors/kongzi",
     "name": "孔子",
     "pinyin": "Kongzi",
     "latinized": "Confucius",
     "links": {
+      "profile": "http://literature.example.com/profiles/scholar",
+      "self": "http://literature.example.com/authors/kongzi",
+      "http://literature.example.com/rels/quotes": "http://literature.example.com/quotes/?author=kongzi&q={query}",
       "works": {"linkage": [{"type": "works", "id": 11}, {"type": "works", "id": 12}]}
     }
   },
@@ -14,10 +16,11 @@
       {
         "id": 11,
         "type": "works",
-        "href": "http://literature.example.com/work/11",
         "chinese_name": "論語",
         "english_name": "Analects",
         "links": {
+          "profile": "http://literature.example.com/profiles/work",
+          "self": "http://literature.example.com/work/11",
           "quotes": {"linkage": [{"type": "quotes", "id": 17}, {"type": "quotes", "id": 18}]},
           "era": {"linkage": {"type": "erae", "id": 99}}
         }
@@ -40,9 +43,12 @@
       {
         "id": 12,
         "type": "works",
-        "href": "http://literature.example.com/work/12",
         "chinese_name": "易經",
-        "english_name": "Commentaries to the Yi-jing"
+        "english_name": "Commentaries to the Yi-jing",
+        "links": {
+          "profile": "http://literature.example.com/profiles/work",
+          "self": "http://literature.example.com/work/12"
+        }
       }
   ]
 }

--- a/yaks/spec/json/confucius.json_api.json
+++ b/yaks/spec/json/confucius.json_api.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "id": 9,
+    "id": "9",
     "type": "scholars",
     "attributes": {
       "name": "孔子",
@@ -11,12 +11,12 @@
       "profile": "http://literature.example.com/profiles/scholar",
       "self": "http://literature.example.com/authors/kongzi",
       "http://literature.example.com/rels/quotes": "http://literature.example.com/quotes/?author=kongzi&q={query}",
-      "works": {"linkage": [{"type": "works", "id": 11}, {"type": "works", "id": 12}]}
+      "works": {"linkage": [{"type": "works", "id": "11"}, {"type": "works", "id": "12"}]}
     }
   },
   "included": [
       {
-        "id": 11,
+        "id": "11",
         "type": "works",
         "attributes": {
           "chinese_name": "論語",
@@ -25,33 +25,33 @@
         "links": {
           "profile": "http://literature.example.com/profiles/work",
           "self": "http://literature.example.com/work/11",
-          "quotes": {"linkage": [{"type": "quotes", "id": 17}, {"type": "quotes", "id": 18}]},
-          "era": {"linkage": {"type": "erae", "id": 99}}
+          "quotes": {"linkage": [{"type": "quotes", "id": "17"}, {"type": "quotes", "id": "18"}]},
+          "era": {"linkage": {"type": "erae", "id": "99"}}
         }
       },
       {
-        "id": 17,
+        "id": "17",
         "type": "quotes",
         "attributes": {
           "chinese": "廄焚。子退朝，曰：“傷人乎？” 不問馬。"
         }
       },
       {
-        "id": 18,
+        "id": "18",
         "type": "quotes",
         "attributes": {
           "chinese": "子曰：“其恕乎！己所不欲、勿施於人。”"
         }
       },
       {
-        "id": 99,
+        "id": "99",
         "type": "erae",
         "attributes": {
           "name": "Zhou Dynasty"
         }
       },
       {
-        "id": 12,
+        "id": "12",
         "type": "works",
         "attributes": {
           "chinese_name": "易經",

--- a/yaks/spec/json/confucius.json_api.json
+++ b/yaks/spec/json/confucius.json_api.json
@@ -2,9 +2,11 @@
   "data": {
     "id": 9,
     "type": "scholars",
-    "name": "孔子",
-    "pinyin": "Kongzi",
-    "latinized": "Confucius",
+    "attributes": {
+      "name": "孔子",
+      "pinyin": "Kongzi",
+      "latinized": "Confucius"
+    },
     "links": {
       "profile": "http://literature.example.com/profiles/scholar",
       "self": "http://literature.example.com/authors/kongzi",
@@ -16,8 +18,10 @@
       {
         "id": 11,
         "type": "works",
-        "chinese_name": "論語",
-        "english_name": "Analects",
+        "attributes": {
+          "chinese_name": "論語",
+          "english_name": "Analects"
+        },
         "links": {
           "profile": "http://literature.example.com/profiles/work",
           "self": "http://literature.example.com/work/11",
@@ -28,23 +32,31 @@
       {
         "id": 17,
         "type": "quotes",
-        "chinese": "廄焚。子退朝，曰：“傷人乎？” 不問馬。"
+        "attributes": {
+          "chinese": "廄焚。子退朝，曰：“傷人乎？” 不問馬。"
+        }
       },
       {
         "id": 18,
         "type": "quotes",
-        "chinese": "子曰：“其恕乎！己所不欲、勿施於人。”"
+        "attributes": {
+          "chinese": "子曰：“其恕乎！己所不欲、勿施於人。”"
+        }
       },
       {
         "id": 99,
         "type": "erae",
-        "name": "Zhou Dynasty"
+        "attributes": {
+          "name": "Zhou Dynasty"
+        }
       },
       {
         "id": 12,
         "type": "works",
-        "chinese_name": "易經",
-        "english_name": "Commentaries to the Yi-jing",
+        "attributes": {
+          "chinese_name": "易經",
+          "english_name": "Commentaries to the Yi-jing"
+        },
         "links": {
           "profile": "http://literature.example.com/profiles/work",
           "self": "http://literature.example.com/work/12"

--- a/yaks/spec/json/list_of_quotes.json_api.json
+++ b/yaks/spec/json/list_of_quotes.json_api.json
@@ -2,21 +2,21 @@
   "data": [
     {
       "type": "quotes",
-      "id": 17,
+      "id": "17",
       "attributes": {
         "chinese": "廄焚。子退朝，曰：“傷人乎？” 不問馬。"
       }
     },
     {
       "type": "quotes",
-      "id": 18,
+      "id": "18",
       "attributes": {
         "chinese": "子曰：“其恕乎！己所不欲、勿施於人。”"
       }
     },
     {
       "type": "quotes",
-      "id": 99,
+      "id": "99",
       "attributes": {
         "chinese": null
       }

--- a/yaks/spec/json/list_of_quotes.json_api.json
+++ b/yaks/spec/json/list_of_quotes.json_api.json
@@ -3,17 +3,23 @@
     {
       "type": "quotes",
       "id": 17,
-      "chinese": "廄焚。子退朝，曰：“傷人乎？” 不問馬。"
+      "attributes": {
+        "chinese": "廄焚。子退朝，曰：“傷人乎？” 不問馬。"
+      }
     },
     {
       "type": "quotes",
       "id": 18,
-      "chinese": "子曰：“其恕乎！己所不欲、勿施於人。”"
+      "attributes": {
+        "chinese": "子曰：“其恕乎！己所不欲、勿施於人。”"
+      }
     },
     {
       "type": "quotes",
       "id": 99,
-      "chinese": null
+      "attributes": {
+        "chinese": null
+      }
     }
   ]
 }

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Yaks::Format::JsonAPI do
 
     it 'should not include an "included" key' do
       expect(format.call(resource)).to eql(
-        data: {type: :wizards, attributes: {foo: :bar}}
+        data: {type: 'wizards', attributes: {foo: :bar}}
       )
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe Yaks::Format::JsonAPI do
     it 'should include the "meta" key' do
       expect(format.call(resource)).to eql(
         meta: {page: {limit: 20, offset: 0, count: 25}},
-        data: [{type: :wizards, attributes: {foo: :bar}}]
+        data: [{type: 'wizards', attributes: {foo: :bar}}]
       )
     end
   end
@@ -46,14 +46,14 @@ RSpec.describe Yaks::Format::JsonAPI do
     it 'should include the links in the "links" key' do
       expect(format.call(resource)).to eql(
         data: {
-          type: :wizards,
+          type: 'wizards',
           links: {
             self: "/the/self/link",
             profile: "/the/profile/link",
             'favourite_spell' => {linkage: {type: "spells", id: "1"}},
           }
         },
-        included: [{type: :spells, id: "1"}]
+        included: [{type: 'spells', id: "1"}]
       )
     end
   end
@@ -71,10 +71,10 @@ RSpec.describe Yaks::Format::JsonAPI do
     it 'should include subresource links and included' do
       expect(format.call(resource)).to eql(
         data: {
-          type: :wizards,
+          type: 'wizards',
           links: {'favourite_spell'  => {linkage: {type: 'spells', id: "777"}}}
         },
-        included: [{type: :spells, id: "777", attributes: {name: 'Lucky Sevens'}}]
+        included: [{type: 'spells', id: "777", attributes: {name: 'Lucky Sevens'}}]
       )
     end
   end
@@ -103,15 +103,15 @@ RSpec.describe Yaks::Format::JsonAPI do
     it 'should include the each subresource only once' do
       expect(format.call(resource)).to eql(
         data: [
-          {type: :wizards, id: '7', links: {'favourite_spell' => {linkage: {type: 'spells', id: '1'}}}},
-          {type: :wizards, id: '3', links: {'favourite_spell' => {linkage: {type: 'spells', id: '1'}}}},
-          {type: :wizards, id: '2', links: {'favourite_spell' => {linkage: {type: 'spells', id: '12'}}}},
-          {type: :wizards, id: '9', links: {'wand'            => {linkage: {type: 'wands',  id: '1'}}}},
+          {type: 'wizards', id: '7', links: {'favourite_spell' => {linkage: {type: 'spells', id: '1'}}}},
+          {type: 'wizards', id: '3', links: {'favourite_spell' => {linkage: {type: 'spells', id: '1'}}}},
+          {type: 'wizards', id: '2', links: {'favourite_spell' => {linkage: {type: 'spells', id: '12'}}}},
+          {type: 'wizards', id: '9', links: {'wand'            => {linkage: {type: 'wands',  id: '1'}}}},
         ],
         included: [
-          {type: :spells, id: '1'},
-          {type: :spells, id: '12'},
-          {type: :wands,  id: '1'},
+          {type: 'spells', id: '1'},
+          {type: 'spells', id: '12'},
+          {type: 'wands',  id: '1'},
         ]
       )
     end
@@ -127,7 +127,7 @@ RSpec.describe Yaks::Format::JsonAPI do
 
     it 'should not include subresource links' do
       expect(format.call(resource)).to eql(
-        data: {type: :wizards}
+        data: {type: 'wizards'}
       )
     end
   end
@@ -142,7 +142,7 @@ RSpec.describe Yaks::Format::JsonAPI do
 
     it 'should not include subresource links' do
       expect(format.call(resource)).to eql(
-        data: {type: :wizards}
+        data: {type: 'wizards'}
       )
     end
   end

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -50,10 +50,10 @@ RSpec.describe Yaks::Format::JsonAPI do
           links: {
             self: "/the/self/link",
             profile: "/the/profile/link",
-            'favourite_spell' => {linkage: {type: "spells", id: 1}},
+            'favourite_spell' => {linkage: {type: "spells", id: "1"}},
           }
         },
-        included: [{type: :spells, id: 1}]
+        included: [{type: :spells, id: "1"}]
       )
     end
   end
@@ -72,9 +72,9 @@ RSpec.describe Yaks::Format::JsonAPI do
       expect(format.call(resource)).to eql(
         data: {
           type: :wizards,
-          links: {'favourite_spell'  => {linkage: {type: 'spells', id: 777}}}
+          links: {'favourite_spell'  => {linkage: {type: 'spells', id: "777"}}}
         },
-        included: [{type: :spells, id: 777, attributes: {name: 'Lucky Sevens'}}]
+        included: [{type: :spells, id: "777", attributes: {name: 'Lucky Sevens'}}]
       )
     end
   end

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Yaks::Format::JsonAPI do
 
     it 'should not include an "included" key' do
       expect(format.call(resource)).to eql(
-        data: {type: :wizards, foo: :bar}
+        data: {type: :wizards, attributes: {foo: :bar}}
       )
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe Yaks::Format::JsonAPI do
     it 'should include the "meta" key' do
       expect(format.call(resource)).to eql(
         meta: {page: {limit: 20, offset: 0, count: 25}},
-        data: [{type: :wizards, foo: :bar}]
+        data: [{type: :wizards, attributes: {foo: :bar}}]
       )
     end
   end
@@ -74,7 +74,7 @@ RSpec.describe Yaks::Format::JsonAPI do
           type: :wizards,
           links: {'favourite_spell'  => {linkage: {type: 'spells', id: 777}}}
         },
-        included: [{type: :spells, id: 777, name: 'Lucky Sevens'}]
+        included: [{type: :spells, id: 777, attributes: {name: 'Lucky Sevens'}}]
       )
     end
   end


### PR DESCRIPTION
What the heck, I really want to stay updated with JSON-API, and hopefully 1.0 will be released soon. The new change with the "attributes" key was totally justified, even though it wouldn't be necessary if there wasn't for "data" key in the first place.

I couldn't figure out how to get acceptance tests passing, regarding the links. I tried in the console, and the links are generated fine. But in acceptance tests the links are just eaten up, and there is always this "href", even though JSON-API doesn't set it anywhere (I removed it because JSON-API removed it). After a lot of debugging I found out that the JSON-API acceptance test doesn't even use `Yaks::Mapper#call`. What is going on there? :P