### PR TITLE
Cache Bundler on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ rvm:
   - rbx
   - ruby-head
 
+cache: bundler
+
 sudo: false
 
 script: bundle exec rake $TASK


### PR DESCRIPTION
Travis supports caching Bundler dependencies. According to my calculation, this should make builds around 3x faster.