### PR TITLE
More derivation options

### DIFF
--- a/yaks/README.md
+++ b/yaks/README.md
@@ -630,7 +630,7 @@ yaks = Yaks.new do
     # ...
   end
 
-  derive_mapper_from_single_object do |model|
+  derive_mapper_from_item do |model|
     # ...
   end
 
@@ -676,7 +676,7 @@ yaks.call(array_of_widgets, mapper: MyCollectionMapper, item_mapper: WidgetMappe
 ```
 
 If the mapper is left unspecified, Yaks will inspect whatever you pass
-it, and call `derive_mapper_from_single_object` or `derive_mapper_from_collection`
+it, and call `derive_mapper_from_item` or `derive_mapper_from_collection`
 depending on whether the given object is a collection or not. If the object responds
 to `to_ary` it is considered a collection.
 
@@ -697,7 +697,7 @@ it's important that empty collections are handled by the right mapper
 (e.g. to set a specific `self` or `profile` link), then you have to be
 explicit.
 
-### derive_mapper_from_single_object
+### derive_mapper_from_item
 
 When using this method, the lookup happens based on the class name,
 and will traverse up the class hierarchy in the configured namespace if

--- a/yaks/README.md
+++ b/yaks/README.md
@@ -685,11 +685,22 @@ to `to_ary` it is considered a collection.
 
 ### mapper_for
 
-This method allows you to define one-to-one mapping between a class
-and its mapper class. For example, when using `mapper_for(Post, SpecialMapper)`,
-Yaks would always derive `SpecialMapper` from an instance of `Post`.
+This method allows you to define a one-to-one mapping between a mapping rule and a mapper class.
+During the lookup, Yaks will check if any mapping rule matches the given object using the `#===`
+operator.
 
-A mapping defined this way will have the highest priority during lookup.
+Here are a few examples on how to use it:
+```ruby
+yaks = Yaks.new do
+  mapper_for(:home, HomeMapper)
+  mapper_for(Post, SpecialMapper)
+  mapper_for(->(author) { author.respond_to?(:name) && author.name == 'doh' }, AuthorMapper)
+end
+
+yaks.call(:home) # would map using HomeMapper
+yaks.call(Post.new) # would map using PostMapper
+yaks.call(Author.new(name: 'doh')) # would map using AuthorMapper
+```
 
 ### derive_mapper_from_collection
 This method will try various constant lookups based on naming. These all happen

--- a/yaks/README.md
+++ b/yaks/README.md
@@ -626,6 +626,14 @@ yaks = Yaks.new do
     # ...
   end
 
+  derive_mapper_from_collection do |collection|
+    # ...
+  end
+
+  derive_mapper_from_single_object do |model|
+    # ...
+  end
+
   derive_type_from_mapper_class do |mapper_class|
     # ...
   end
@@ -639,6 +647,9 @@ yaks = Yaks.new do
   end
 end
 ```
+
+Note that within these blocks, you may call `super()` which would call
+the default implementation.
 
 You can also subclass or create from scratch your own policy class
 
@@ -665,11 +676,15 @@ yaks.call(array_of_widgets, mapper: MyCollectionMapper, item_mapper: WidgetMappe
 ```
 
 If the mapper is left unspecified, Yaks will inspect whatever you pass
-it, and try various constant lookups based on naming. These all happen
+it, and call `derive_mapper_from_single_object` or `derive_mapper_from_collection`
+depending on whether the given object is a collection or not. If the object responds
+to `to_ary` it is considered a collection.
+
+### derive_mapper_from_collection
+This method will try various constant lookups based on naming. These all happen
 in the configured namespace, which defaults to the Ruby top level.
 
-If the object responds to `to_ary` it is considered a collection. If
-the first object in the collection has a class of `Widget`, and the
+If the first object in the collection has a class of `Widget`, and the
 configured namespace is `API`, then these are tried in turn
 
 * `API::WidgetCollectionMapper`
@@ -682,9 +697,11 @@ it's important that empty collections are handled by the right mapper
 (e.g. to set a specific `self` or `profile` link), then you have to be
 explicit.
 
-If the object is not a collection, then lookup happens based on the
-class name, and will traverse up the class hierarchy if no suitable
-mapper is found. Take the following
+### derive_mapper_from_single_object
+
+When using this method, the lookup happens based on the class name,
+and will traverse up the class hierarchy in the configured namespace if
+no suitable mapper is found. Take the following
 code:
 ```ruby
 module Stuff

--- a/yaks/README.md
+++ b/yaks/README.md
@@ -622,6 +622,8 @@ In Yaks whenever missing values need to be inferred, like finding an unspecified
 
 ```ruby
 yaks = Yaks.new do
+  mapper_for Post, SpecialMapper
+
   derive_mapper_from_object do |model|
     # ...
   end
@@ -676,9 +678,18 @@ yaks.call(array_of_widgets, mapper: MyCollectionMapper, item_mapper: WidgetMappe
 ```
 
 If the mapper is left unspecified, Yaks will inspect whatever you pass
-it, and call `derive_mapper_from_item` or `derive_mapper_from_collection`
+it. First it will test the given object against the mappings defined using `mapper_for`.
+If no mapper is found, it will call `derive_mapper_from_item` or `derive_mapper_from_collection`
 depending on whether the given object is a collection or not. If the object responds
 to `to_ary` it is considered a collection.
+
+### mapper_for
+
+This method allows you to define one-to-one mapping between a class
+and its mapper class. For example, when using `mapper_for(Post, SpecialMapper)`,
+Yaks would always derive `SpecialMapper` from an instance of `Post`.
+
+A mapping defined this way will have the highest priority during lookup.
 
 ### derive_mapper_from_collection
 This method will try various constant lookups based on naming. These all happen

--- a/yaks/ataru_setup.rb
+++ b/yaks/ataru_setup.rb
@@ -4,6 +4,7 @@ require "yaks"
 require "hamster"
 
 Post = Struct.new(:id, :title, :author, :comments)
+Author = Struct.new(:name)
 
 module MyAPI
   Product = Struct.new(:id, :label)
@@ -28,7 +29,9 @@ class PostMapper < Yaks::Mapper
   has_many :comments
 end
 
-class SpecialMapper; end
+class HomeMapper < Yaks::Mapper; end
+
+class SpecialMapper < Yaks::Mapper; end
 
 module Setup
   def setup

--- a/yaks/ataru_setup.rb
+++ b/yaks/ataru_setup.rb
@@ -28,6 +28,8 @@ class PostMapper < Yaks::Mapper
   has_many :comments
 end
 
+class SpecialMapper; end
+
 module Setup
   def setup
     # Do some nice setup that is run before every snippet

--- a/yaks/lib/yaks.rb
+++ b/yaks/lib/yaks.rb
@@ -31,6 +31,7 @@ module Yaks
   DSL_METHODS = [
     :format_options,
     :rel_template,
+    :mapper_for,
     :before,
     :after,
     :around,

--- a/yaks/lib/yaks/config.rb
+++ b/yaks/lib/yaks/config.rb
@@ -44,6 +44,12 @@ module Yaks
       with(policy_options: policy_options.merge(namespace: namespace))
     end
 
+    def mapper_for(rule, mapper_class)
+      policy_options[:mapper_rules] ||= {}
+      mapper_rules = policy_options[:mapper_rules].merge(rule => mapper_class)
+      with(policy_options: policy_options.merge(mapper_rules: mapper_rules))
+    end
+
     def map_to_primitive(*args, &block)
       with(primitivize: primitivize.dup.tap { |prim| prim.map(*args, &block) })
     end

--- a/yaks/lib/yaks/default_policy.rb
+++ b/yaks/lib/yaks/default_policy.rb
@@ -6,7 +6,8 @@ module Yaks
     # Default policy options.
     DEFAULTS = {
       rel_template: "rel:{rel}",
-      namespace: Object
+      namespace: Object,
+      mapper_rules: {}
     }
 
     # @!attribute [r]
@@ -27,6 +28,8 @@ module Yaks
     #
     # @raise [RuntimeError] occurs when no mapper is found
     def derive_mapper_from_object(model)
+      mapper = detect_configured_mapper_for(model)
+      return mapper if mapper
       return derive_mapper_from_collection(model) if model.respond_to? :to_ary
       derive_mapper_from_item(model)
     end
@@ -120,6 +123,15 @@ module Yaks
     # @return [String]
     def expand_rel(relname)
       URITemplate.new(@options[:rel_template]).expand(rel: relname)
+    end
+
+    private
+
+    def detect_configured_mapper_for(object)
+      @options[:mapper_rules].each do |rule, mapper_class|
+        return mapper_class if rule === object # rubocop:disable Style/CaseEquality
+      end
+      nil
     end
   end
 end

--- a/yaks/lib/yaks/default_policy.rb
+++ b/yaks/lib/yaks/default_policy.rb
@@ -19,7 +19,7 @@ module Yaks
     end
 
     # Main point of entry for mapper derivation. Calls
-    # derive_mapper_from_collection or derive_mapper_from_single_object
+    # derive_mapper_from_collection or derive_mapper_from_item
     # depending on the model.
     #
     # @param model [Object]
@@ -28,7 +28,7 @@ module Yaks
     # @raise [RuntimeError] occurs when no mapper is found
     def derive_mapper_from_object(model)
       return derive_mapper_from_collection(model) if model.respond_to? :to_ary
-      derive_mapper_from_single_object(model)
+      derive_mapper_from_item(model)
     end
 
     # Derives a mapper from the given collection.
@@ -50,32 +50,32 @@ module Yaks
       CollectionMapper
     end
 
-    # Derives a mapper from the given object. This object should not
+    # Derives a mapper from the given item. This item should not
     # be a collection.
     #
-    # @param object [Object]
+    # @param item [Object]
     # @return [Class] A mapper, typically a subclass of Yaks::Mapper
     #
-    # @raise [RuntimeError] only occurs when no mapper is found for the given object.
-    def derive_mapper_from_single_object(object)
-      klass = object.class
+    # @raise [RuntimeError] only occurs when no mapper is found for the given item.
+    def derive_mapper_from_item(item)
+      klass = item.class
       splitted_class_name = klass.name.split("::")
-      object_namespace = splitted_class_name[0...-1]
-      object_class_name = splitted_class_name.last
+      item_namespace = splitted_class_name[0...-1]
+      item_class_name = splitted_class_name.last
       begin
-        mapper_class_parts = [*object_namespace, "#{klass.name.split('::').last}Mapper"]
+        mapper_class_parts = [*item_namespace, "#{klass.name.split('::').last}Mapper"]
         return mapper_class_parts.inject(@options[:namespace]) do |prefix, suffix|
           prefix.const_get(suffix, false)
         end
       rescue NameError
         klass = klass.superclass
-        unless object_namespace.empty? || klass
-          object_namespace = []
-          klass = object.class
+        unless item_namespace.empty? || klass
+          item_namespace = []
+          klass = item.class
         end
         retry if klass
       end
-      raise "Failed to find a mapper for #{object.inspect}. Did you mean to implement #{object_class_name}Mapper?"
+      raise "Failed to find a mapper for #{item.inspect}. Did you mean to implement #{item_class_name}Mapper?"
     end
 
     # Derive the a mapper type name

--- a/yaks/spec/support/classes_for_policy_testing.rb
+++ b/yaks/spec/support/classes_for_policy_testing.rb
@@ -17,6 +17,7 @@ module Grain
   end
 
   class SoyMapper; end
+  class SoyCollectionMapper; end
 end
 
 class WheatMapper; end

--- a/yaks/spec/support/classes_for_policy_testing.rb
+++ b/yaks/spec/support/classes_for_policy_testing.rb
@@ -20,6 +20,7 @@ module Grain
   class SoyCollectionMapper; end
 end
 
+class HomeMapper; end
 class WheatMapper; end
 
 module MyMappers

--- a/yaks/spec/support/pet_mapper.rb
+++ b/yaks/spec/support/pet_mapper.rb
@@ -1,3 +1,5 @@
 class PetMapper < Yaks::Mapper
   attributes :id, :name, :species
 end
+class GreatPetMapper < Yaks::Mapper; end
+class GreatPetCollectionMapper < Yaks::Mapper; end

--- a/yaks/spec/unit/yaks/config_spec.rb
+++ b/yaks/spec/unit/yaks/config_spec.rb
@@ -116,6 +116,59 @@ RSpec.describe Yaks::Config do
     end
   end
 
+  describe '#derive_mapper_from_object' do
+    configure { }
+    let(:object) { Pet.new(id: 7, name: 'fifi', species: 'cat') }
+    subject do
+      config.derive_mapper_from_object do |object|
+        mapper_class = super(object)
+        Object.const_get("Great#{mapper_class.name}")
+      end
+    end
+
+    its(:policy_class) { should <= Yaks::DefaultPolicy }
+
+    it 'should override the policy method' do
+      expect(subject.policy.derive_mapper_from_object(object)).to be GreatPetMapper
+    end
+  end
+
+  describe '#derive_mapper_from_single_object' do
+    configure { }
+    let(:object) { Pet.new(id: 7, name: 'fifi', species: 'cat') }
+    subject do
+      config.derive_mapper_from_single_object do |object|
+        mapper_class = super(object)
+        Object.const_get("Great#{mapper_class.name}")
+      end
+    end
+
+    its(:policy_class) { should <= Yaks::DefaultPolicy }
+
+    it 'should override the policy method' do
+      expect(subject.policy.derive_mapper_from_single_object(object)).to be GreatPetMapper
+      expect(subject.policy.derive_mapper_from_object(object)).to be GreatPetMapper
+    end
+  end
+
+  describe '#derive_mapper_from_collection' do
+    configure { }
+    let(:object) { [Pet.new(id: 7, name: 'fifi', species: 'cat')] }
+    subject do
+      config.derive_mapper_from_collection do |object|
+        mapper_class_name = super(object).name.split('::').last
+        Object.const_get("GreatPet#{mapper_class_name}")
+      end
+    end
+
+    its(:policy_class) { should <= Yaks::DefaultPolicy }
+
+    it 'should override the policy method' do
+      expect(subject.policy.derive_mapper_from_collection(object)).to be GreatPetCollectionMapper
+      expect(subject.policy.derive_mapper_from_object(object)).to be GreatPetCollectionMapper
+    end
+  end
+
   describe '#call' do
     configure do
       rel_template 'http://api.mysuperfriends.com/{rel}'

--- a/yaks/spec/unit/yaks/config_spec.rb
+++ b/yaks/spec/unit/yaks/config_spec.rb
@@ -49,13 +49,16 @@ RSpec.describe Yaks::Config do
     let(:expected_options) do
       {
         namespace: Object,
-        mapper_rules: {Grain::Wheat => SoyMapper, Soy => MyMappers::WheatMapper}
+        mapper_rules: {
+          home: HomeMapper,
+          Soy => MyMappers::WheatMapper
+        }
       }
     end
     configure do
       mapper_namespace Object
       mapper_for Soy, MyMappers::WheatMapper
-      mapper_for Grain::Wheat, SoyMapper
+      mapper_for :home, HomeMapper
     end
 
     its(:policy_options) { should eql(expected_options) }

--- a/yaks/spec/unit/yaks/config_spec.rb
+++ b/yaks/spec/unit/yaks/config_spec.rb
@@ -133,11 +133,11 @@ RSpec.describe Yaks::Config do
     end
   end
 
-  describe '#derive_mapper_from_single_object' do
+  describe '#derive_mapper_from_item' do
     configure { }
     let(:object) { Pet.new(id: 7, name: 'fifi', species: 'cat') }
     subject do
-      config.derive_mapper_from_single_object do |object|
+      config.derive_mapper_from_item do |object|
         mapper_class = super(object)
         Object.const_get("Great#{mapper_class.name}")
       end
@@ -146,7 +146,7 @@ RSpec.describe Yaks::Config do
     its(:policy_class) { should <= Yaks::DefaultPolicy }
 
     it 'should override the policy method' do
-      expect(subject.policy.derive_mapper_from_single_object(object)).to be GreatPetMapper
+      expect(subject.policy.derive_mapper_from_item(object)).to be GreatPetMapper
       expect(subject.policy.derive_mapper_from_object(object)).to be GreatPetMapper
     end
   end

--- a/yaks/spec/unit/yaks/config_spec.rb
+++ b/yaks/spec/unit/yaks/config_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe Yaks::Config do
     its(:policy_options) { should eql(namespace: Object, rel_template: 'http://rel/foo') }
   end
 
+  describe '#mapper_for' do
+    let(:expected_options) do
+      {
+        namespace: Object,
+        mapper_rules: {Grain::Wheat => SoyMapper, Soy => MyMappers::WheatMapper}
+      }
+    end
+    configure do
+      mapper_namespace Object
+      mapper_for Soy, MyMappers::WheatMapper
+      mapper_for Grain::Wheat, SoyMapper
+    end
+
+    its(:policy_options) { should eql(expected_options) }
+  end
+
   describe '#format_options' do
     configure do
       format_options :hal, plural_links: [:self, :profile]

--- a/yaks/spec/unit/yaks/default_policy/derive_mapper_from_collection_spec.rb
+++ b/yaks/spec/unit/yaks/default_policy/derive_mapper_from_collection_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_collection' do
+  subject(:policy) { described_class.new(options) }
+
+  let(:options) { {} }
+
+  context 'given an empty array' do
+    it 'should return the vanilla CollectionMapper' do
+      expect(policy.derive_mapper_from_collection([])).to be Yaks::CollectionMapper
+    end
+  end
+
+  it 'should find the mapper based on naming' do
+    expect(policy.derive_mapper_from_collection([Soy.new])).to be SoyCollectionMapper
+  end
+
+  it 'should not care about the object module' do
+    expect(policy.derive_mapper_from_collection([Grain::Soy.new])).to be SoyCollectionMapper
+  end
+
+  context 'if no collection mapper with a similar name is defined' do
+    let(:options) { {namespace: Namespace} }
+
+    it 'should look for a CollectionMapper in the namespace' do
+      expect(policy.derive_mapper_from_collection([WildSoy.new])).to be(Namespace::CollectionMapper)
+    end
+  end
+
+  context 'when trying to lookup CollectionMapper results in something other than an NameError' do
+    let(:options) { {namespace: DislikesCollectionMapper} }
+
+    it 'should propagate the error' do
+      expect {
+        policy.derive_mapper_from_object([])
+      }.to raise_error
+    end
+  end
+
+  context 'when trying to lookup a specific collection mapper results in something other than an NameError' do
+    let(:options) { {namespace: DislikesOtherMappers} }
+
+    it 'should propagate the error' do
+      expect do
+        policy.derive_mapper_from_object([Namespace::Nested::Rye.new])
+      end.to raise_error
+    end
+  end
+end

--- a/yaks/spec/unit/yaks/default_policy/derive_mapper_from_collection_spec.rb
+++ b/yaks/spec/unit/yaks/default_policy/derive_mapper_from_collection_spec.rb
@@ -23,25 +23,25 @@ RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_collection' do
     it 'should look for a CollectionMapper in the namespace' do
       expect(policy.derive_mapper_from_collection([WildSoy.new])).to be(Namespace::CollectionMapper)
     end
-  end
 
-  context 'when trying to lookup CollectionMapper results in something other than an NameError' do
-    let(:options) { {namespace: DislikesCollectionMapper} }
+    context 'when trying to lookup CollectionMapper results in something other than an NameError' do
+      let(:options) { {namespace: DislikesCollectionMapper} }
 
-    it 'should propagate the error' do
-      expect {
-        policy.derive_mapper_from_object([])
-      }.to raise_error
+      it 'should propagate the error' do
+        expect {
+          policy.derive_mapper_from_object([])
+        }.to raise_error
+      end
     end
-  end
 
-  context 'when trying to lookup a specific collection mapper results in something other than an NameError' do
-    let(:options) { {namespace: DislikesOtherMappers} }
+    context 'when trying to lookup a specific collection mapper results in something other than an NameError' do
+      let(:options) { {namespace: DislikesOtherMappers} }
 
-    it 'should propagate the error' do
-      expect do
-        policy.derive_mapper_from_object([Namespace::Nested::Rye.new])
-      end.to raise_error
+      it 'should propagate the error' do
+        expect do
+          policy.derive_mapper_from_object([Namespace::Nested::Rye.new])
+        end.to raise_error
+      end
     end
   end
 end

--- a/yaks/spec/unit/yaks/default_policy/derive_mapper_from_item_spec.rb
+++ b/yaks/spec/unit/yaks/default_policy/derive_mapper_from_item_spec.rb
@@ -83,7 +83,17 @@ RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_item' do
     it 'should give a nice message' do
       expect do
         policy.derive_mapper_from_item(Namespace::Nested::Mung.new)
-      end.to raise_error /Failed to find a mapper for #<Namespace::Nested::Mung:0x\h+>. Did you mean to implement MungMapper\?/
+      end.to raise_error /Failed to find a mapper for #<Namespace::Nested::Mung:0x\h+>. Did you mean to implement Namespace::Nested::MungMapper\?/
+    end
+
+    context 'with namespace option specified' do
+      let(:options) { {namespace: MyMappers} }
+
+      it 'should give a nice message' do
+        expect do
+          policy.derive_mapper_from_item(Namespace::Nested::Rye.new)
+        end.to raise_error /Failed to find a mapper for #<Namespace::Nested::Rye:0x\h+>. Did you mean to implement MyMappers::Namespace::Nested::RyeMapper\?/
+      end
     end
   end
 end

--- a/yaks/spec/unit/yaks/default_policy/derive_mapper_from_item_spec.rb
+++ b/yaks/spec/unit/yaks/default_policy/derive_mapper_from_item_spec.rb
@@ -1,52 +1,52 @@
-RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_single_object' do
+RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_item' do
   subject(:policy) { described_class.new(options) }
 
   let(:options) { {} }
 
   it 'should use const_get with second argument set to false' do
     stub(Object).const_get(any_args) { SoyMapper }
-    policy.derive_mapper_from_single_object(Soy.new)
+    policy.derive_mapper_from_item(Soy.new)
     expect(Object).to have_received.const_get("SoyMapper", false)
   end
 
   context 'at top level' do
     it 'should derive it by name' do
-      expect(policy.derive_mapper_from_single_object(Soy.new)).to be SoyMapper
+      expect(policy.derive_mapper_from_item(Soy.new)).to be SoyMapper
     end
 
     it 'should look for parent class if not found' do
-      expect(policy.derive_mapper_from_single_object(WildSoy.new)).to be SoyMapper
+      expect(policy.derive_mapper_from_item(WildSoy.new)).to be SoyMapper
     end
 
     context 'with namespace option set' do
       let(:options) { {namespace: MyMappers} }
 
       it 'should look inside the namespace' do
-        expect(policy.derive_mapper_from_single_object(Soy.new)).to be MyMappers::SoyMapper
+        expect(policy.derive_mapper_from_item(Soy.new)).to be MyMappers::SoyMapper
       end
 
       it 'should look for its parent class mapper in the namespace if not found' do
-        expect(policy.derive_mapper_from_single_object(WildSoy.new)).to be MyMappers::SoyMapper
+        expect(policy.derive_mapper_from_item(WildSoy.new)).to be MyMappers::SoyMapper
       end
     end
   end
 
   context 'inside a module' do
     it 'should look inside the module' do
-      expect(policy.derive_mapper_from_single_object(Grain::Soy.new)).to be Grain::SoyMapper
+      expect(policy.derive_mapper_from_item(Grain::Soy.new)).to be Grain::SoyMapper
     end
 
     it 'should look for its parent class mapper in the module if not found' do
-      expect(policy.derive_mapper_from_single_object(Grain::WildSoy.new)).to be Grain::SoyMapper
+      expect(policy.derive_mapper_from_item(Grain::WildSoy.new)).to be Grain::SoyMapper
     end
 
     context 'no mapper defined in module' do
       it 'should look for mapper outside module' do
-        expect(policy.derive_mapper_from_single_object(Grain::Wheat.new)).to be WheatMapper
+        expect(policy.derive_mapper_from_item(Grain::Wheat.new)).to be WheatMapper
       end
 
       it 'should look for its parent class mapper outside module' do
-        expect(policy.derive_mapper_from_single_object(Grain::Durum.new)).to be WheatMapper
+        expect(policy.derive_mapper_from_item(Grain::Durum.new)).to be WheatMapper
       end
     end
 
@@ -54,27 +54,27 @@ RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_single_object' do
       let(:options) { {namespace: MyMappers} }
 
       it 'should look inside the module' do
-        expect(policy.derive_mapper_from_single_object(Grain::Soy.new)).to be MyMappers::Grain::SoyMapper
+        expect(policy.derive_mapper_from_item(Grain::Soy.new)).to be MyMappers::Grain::SoyMapper
       end
 
       it 'should look for its parent class mapper if not found' do
-        expect(policy.derive_mapper_from_single_object(Grain::WildSoy.new)).to be MyMappers::Grain::SoyMapper
+        expect(policy.derive_mapper_from_item(Grain::WildSoy.new)).to be MyMappers::Grain::SoyMapper
       end
 
       context 'no mapper defined in module' do
         it 'should look for mapper in namespace top level' do
-          expect(policy.derive_mapper_from_single_object(Grain::Wheat.new)).to be MyMappers::WheatMapper
+          expect(policy.derive_mapper_from_item(Grain::Wheat.new)).to be MyMappers::WheatMapper
         end
 
         it 'should look for its parent mapper in namespace top level' do
-          expect(policy.derive_mapper_from_single_object(Grain::Durum.new)).to be MyMappers::WheatMapper
+          expect(policy.derive_mapper_from_item(Grain::Durum.new)).to be MyMappers::WheatMapper
         end
       end
     end
 
     context 'deeply nested module' do
       it 'should look inside the module' do
-        expect(policy.derive_mapper_from_single_object(Grain::Dry::Soy.new)).to be Grain::Dry::SoyMapper
+        expect(policy.derive_mapper_from_item(Grain::Dry::Soy.new)).to be Grain::Dry::SoyMapper
       end
     end
   end
@@ -82,7 +82,7 @@ RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_single_object' do
   context 'when no mapper is found' do
     it 'should give a nice message' do
       expect do
-        policy.derive_mapper_from_single_object(Namespace::Nested::Mung.new)
+        policy.derive_mapper_from_item(Namespace::Nested::Mung.new)
       end.to raise_error /Failed to find a mapper for #<Namespace::Nested::Mung:0x\h+>. Did you mean to implement MungMapper\?/
     end
   end

--- a/yaks/spec/unit/yaks/default_policy/derive_mapper_from_object_spec.rb
+++ b/yaks/spec/unit/yaks/default_policy/derive_mapper_from_object_spec.rb
@@ -1,149 +1,23 @@
 RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_object' do
-  subject(:policy) { described_class.new(options) }
-
-  let(:options) { {} }
-
-  it 'should use const_get with second argument set to false' do
-    stub(Object).const_get(any_args) { SoyMapper }
-    policy.derive_mapper_from_object(Soy.new)
-    expect(Object).to have_received.const_get("SoyMapper", false)
-  end
+  subject(:policy) { described_class.new }
 
   context 'for a single instance' do
-    context 'outside a module' do
-      it 'should derive it by name' do
-        expect(policy.derive_mapper_from_object(Soy.new)).to be SoyMapper
-      end
+    let(:object) { Soy.new }
 
-      it 'should look for parent class if not found' do
-        expect(policy.derive_mapper_from_object(WildSoy.new)).to be SoyMapper
-      end
-
-      context 'with namespace option set' do
-        let(:options) { {namespace: MyMappers} }
-
-        it 'should look inside the namespace' do
-          expect(policy.derive_mapper_from_object(Soy.new)).to be MyMappers::SoyMapper
-        end
-
-        it 'should look for its parent class mapper in the namespace if not found' do
-          expect(policy.derive_mapper_from_object(WildSoy.new)).to be MyMappers::SoyMapper
-        end
-      end
-    end
-
-    context 'inside a module' do
-      it 'should look inside the module' do
-        expect(policy.derive_mapper_from_object(Grain::Soy.new)).to be Grain::SoyMapper
-      end
-
-      it 'should look for its parent class mapper in the module if not found' do
-        expect(policy.derive_mapper_from_object(Grain::WildSoy.new)).to be Grain::SoyMapper
-      end
-
-      context 'no mapper defined in module' do
-        it 'should look for mapper outside module' do
-          expect(policy.derive_mapper_from_object(Grain::Wheat.new)).to be WheatMapper
-        end
-
-        it 'should look for its parent class mapper outside module' do
-          expect(policy.derive_mapper_from_object(Grain::Durum.new)).to be WheatMapper
-        end
-      end
-
-      context 'with namespace option set' do
-        let(:options) { {namespace: MyMappers} }
-
-        it 'should look inside the module' do
-          expect(policy.derive_mapper_from_object(Grain::Soy.new)).to be MyMappers::Grain::SoyMapper
-        end
-
-        it 'should look for its parent class mapper if not found' do
-          expect(policy.derive_mapper_from_object(Grain::WildSoy.new)).to be MyMappers::Grain::SoyMapper
-        end
-
-        context 'no mapper defined in module' do
-          it 'should look for mapper in namespace top level' do
-            expect(policy.derive_mapper_from_object(Grain::Wheat.new)).to be MyMappers::WheatMapper
-          end
-
-          it 'should look for its parent mapper in namespace top level' do
-            expect(policy.derive_mapper_from_object(Grain::Durum.new)).to be MyMappers::WheatMapper
-          end
-        end
-      end
-
-      context 'deeply nested module' do
-        it 'should look inside the module' do
-          expect(policy.derive_mapper_from_object(Grain::Dry::Soy.new)).to be Grain::Dry::SoyMapper
-        end
-      end
+    it 'should call derive_mapper_for_single_object' do
+      stub(policy).derive_mapper_from_single_object(object) { SoyMapper }
+      policy.derive_mapper_from_object(object)
+      expect(policy).to have_received.derive_mapper_from_single_object(object)
     end
   end
 
   context 'for array-like objects' do
-    context 'given an empty array' do
-      it 'should return the vanilla CollectionMapper' do
-        expect(policy.derive_mapper_from_object([])).to be Yaks::CollectionMapper
-      end
-    end
+    let(:object) { [Soy.new] }
 
-    it 'should find the mapper based on naming' do
-      expect(policy.derive_mapper_from_object([Soy.new])).to be SoyCollectionMapper
-    end
-
-    context 'if no collection mapper with a similar name is defined' do
-      let(:options) { {namespace: Namespace} }
-
-      it 'should look for a CollectionMapper in the namespace' do
-        expect(policy.derive_mapper_from_object([WildSoy.new])).to be(
-          Namespace::CollectionMapper
-        )
-      end
-    end
-  end
-
-  context 'for a model class inside a module' do
-    let(:options) { {namespace: Namespace} }
-
-    it 'should take the non-qualified classname, and search the mapper namespace with that' do
-      expect(policy.derive_mapper_from_object(Namespace::Nested::Rye.new)).to be(
-        Namespace::RyeMapper
-      )
-    end
-
-    it 'should take the non-qualified classname when looking for a collection mapper' do
-      expect(policy.derive_mapper_from_object([Namespace::Nested::Rye.new])).to be(
-        Namespace::RyeCollectionMapper
-      )
-    end
-  end
-
-  context 'when trying to lookup CollectionMapper results in something other than an NameError' do
-    let(:options) { {namespace: DislikesCollectionMapper} }
-
-    it 'should propagate the error' do
-      expect {
-        policy.derive_mapper_from_object([])
-      }.to raise_error
-    end
-  end
-
-  context 'when trying to lookup a specific collection mapper results in something other than an NameError' do
-    let(:options) { {namespace: DislikesOtherMappers} }
-
-    it 'should propagate the error' do
-      expect do
-        policy.derive_mapper_from_object([Namespace::Nested::Rye.new])
-      end.to raise_error
-    end
-  end
-
-  context 'when no mapper is found' do
-    it 'should give a nice message' do
-      expect do
-        policy.derive_mapper_from_object(Namespace::Nested::Mung.new)
-      end.to raise_error /Failed to find a mapper for #<Namespace::Nested::Mung:0x\h+>. Did you mean to implement MungMapper\?/
+    it 'should call derive_mapper_for_single_object' do
+      stub(policy).derive_mapper_from_collection(object) { SoyCollectionMapper }
+      policy.derive_mapper_from_object(object)
+      expect(policy).to have_received.derive_mapper_from_collection(object)
     end
   end
 end

--- a/yaks/spec/unit/yaks/default_policy/derive_mapper_from_object_spec.rb
+++ b/yaks/spec/unit/yaks/default_policy/derive_mapper_from_object_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_object' do
   context 'for a single instance' do
     let(:object) { Soy.new }
 
-    it 'should call derive_mapper_for_single_object' do
-      stub(policy).derive_mapper_from_single_object(object) { SoyMapper }
+    it 'should call derive_mapper_for_item' do
+      stub(policy).derive_mapper_from_item(object) { SoyMapper }
       policy.derive_mapper_from_object(object)
-      expect(policy).to have_received.derive_mapper_from_single_object(object)
+      expect(policy).to have_received.derive_mapper_from_item(object)
     end
   end
 
   context 'for array-like objects' do
     let(:object) { [Soy.new] }
 
-    it 'should call derive_mapper_for_single_object' do
+    it 'should call derive_mapper_for_item' do
       stub(policy).derive_mapper_from_collection(object) { SoyCollectionMapper }
       policy.derive_mapper_from_object(object)
       expect(policy).to have_received.derive_mapper_from_collection(object)

--- a/yaks/spec/unit/yaks/default_policy/derive_mapper_from_object_spec.rb
+++ b/yaks/spec/unit/yaks/default_policy/derive_mapper_from_object_spec.rb
@@ -22,12 +22,31 @@ RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_object' do
   end
 
   context 'mapper_for options set' do
-    let(:object) { Soy.new }
-    let(:options) { {mapper_rules: {WildSoy => MyMappers::SoyMapper, Soy => MyMappers::WheatMapper}} }
     subject(:policy) { described_class.new(options) }
 
-    it 'should use the mapping' do
-      expect(policy.derive_mapper_from_object(object)).to be MyMappers::WheatMapper
+    context 'when mapping a class' do
+      let(:options) { {mapper_rules: {home: HomeMapper, Soy => MyMappers::WheatMapper}} }
+
+      it 'should use the mapping' do
+        expect(policy.derive_mapper_from_object(Soy.new)).to be MyMappers::WheatMapper
+      end
+    end
+
+    context 'when mapping a symbol' do
+      let(:options) { {mapper_rules: {soy: SoyMapper}} }
+
+      it 'should use the mapping' do
+        expect(policy.derive_mapper_from_object(:soy)).to be SoyMapper
+      end
+    end
+
+    context 'when mapping a lambda' do
+      let(:user) { fake(logged_in?: true) }
+      let(:options) { {mapper_rules: {->(user){ user.logged_in? } => SoyMapper}} }
+
+      it 'should use the mapping' do
+        expect(policy.derive_mapper_from_object(user)).to be SoyMapper
+      end
     end
   end
 end

--- a/yaks/spec/unit/yaks/default_policy/derive_mapper_from_object_spec.rb
+++ b/yaks/spec/unit/yaks/default_policy/derive_mapper_from_object_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_object' do
       expect(policy).to have_received.derive_mapper_from_collection(object)
     end
   end
+
+  context 'mapper_for options set' do
+    let(:object) { Soy.new }
+    let(:options) { {mapper_rules: {WildSoy => MyMappers::SoyMapper, Soy => MyMappers::WheatMapper}} }
+    subject(:policy) { described_class.new(options) }
+
+    it 'should use the mapping' do
+      expect(policy.derive_mapper_from_object(object)).to be MyMappers::WheatMapper
+    end
+  end
 end

--- a/yaks/spec/unit/yaks/default_policy/derive_mapper_from_single_object_spec.rb
+++ b/yaks/spec/unit/yaks/default_policy/derive_mapper_from_single_object_spec.rb
@@ -1,0 +1,89 @@
+RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_single_object' do
+  subject(:policy) { described_class.new(options) }
+
+  let(:options) { {} }
+
+  it 'should use const_get with second argument set to false' do
+    stub(Object).const_get(any_args) { SoyMapper }
+    policy.derive_mapper_from_single_object(Soy.new)
+    expect(Object).to have_received.const_get("SoyMapper", false)
+  end
+
+  context 'at top level' do
+    it 'should derive it by name' do
+      expect(policy.derive_mapper_from_single_object(Soy.new)).to be SoyMapper
+    end
+
+    it 'should look for parent class if not found' do
+      expect(policy.derive_mapper_from_single_object(WildSoy.new)).to be SoyMapper
+    end
+
+    context 'with namespace option set' do
+      let(:options) { {namespace: MyMappers} }
+
+      it 'should look inside the namespace' do
+        expect(policy.derive_mapper_from_single_object(Soy.new)).to be MyMappers::SoyMapper
+      end
+
+      it 'should look for its parent class mapper in the namespace if not found' do
+        expect(policy.derive_mapper_from_single_object(WildSoy.new)).to be MyMappers::SoyMapper
+      end
+    end
+  end
+
+  context 'inside a module' do
+    it 'should look inside the module' do
+      expect(policy.derive_mapper_from_single_object(Grain::Soy.new)).to be Grain::SoyMapper
+    end
+
+    it 'should look for its parent class mapper in the module if not found' do
+      expect(policy.derive_mapper_from_single_object(Grain::WildSoy.new)).to be Grain::SoyMapper
+    end
+
+    context 'no mapper defined in module' do
+      it 'should look for mapper outside module' do
+        expect(policy.derive_mapper_from_single_object(Grain::Wheat.new)).to be WheatMapper
+      end
+
+      it 'should look for its parent class mapper outside module' do
+        expect(policy.derive_mapper_from_single_object(Grain::Durum.new)).to be WheatMapper
+      end
+    end
+
+    context 'with namespace option set' do
+      let(:options) { {namespace: MyMappers} }
+
+      it 'should look inside the module' do
+        expect(policy.derive_mapper_from_single_object(Grain::Soy.new)).to be MyMappers::Grain::SoyMapper
+      end
+
+      it 'should look for its parent class mapper if not found' do
+        expect(policy.derive_mapper_from_single_object(Grain::WildSoy.new)).to be MyMappers::Grain::SoyMapper
+      end
+
+      context 'no mapper defined in module' do
+        it 'should look for mapper in namespace top level' do
+          expect(policy.derive_mapper_from_single_object(Grain::Wheat.new)).to be MyMappers::WheatMapper
+        end
+
+        it 'should look for its parent mapper in namespace top level' do
+          expect(policy.derive_mapper_from_single_object(Grain::Durum.new)).to be MyMappers::WheatMapper
+        end
+      end
+    end
+
+    context 'deeply nested module' do
+      it 'should look inside the module' do
+        expect(policy.derive_mapper_from_single_object(Grain::Dry::Soy.new)).to be Grain::Dry::SoyMapper
+      end
+    end
+  end
+
+  context 'when no mapper is found' do
+    it 'should give a nice message' do
+      expect do
+        policy.derive_mapper_from_single_object(Namespace::Nested::Mung.new)
+      end.to raise_error /Failed to find a mapper for #<Namespace::Nested::Mung:0x\h+>. Did you mean to implement MungMapper\?/
+    end
+  end
+end


### PR DESCRIPTION
Based on the discussions in #72 and #76, `derive_mapper_from_collection` and `derive_mapper_from_single_object ` can now be overriden independently and `derive_mapper_from_object` will call either of these two depending on the object type.

The `mapper_for` option is now available too.