### PR TITLE
Added --trace option to rbx tasks on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
   - 2.2
   - jruby
   - jruby-head
-  - rbx
   - ruby-head
 
 sudo: false
@@ -25,6 +24,10 @@ matrix:
     - env: TASK=mutant
   fast_finish: true
   include:
+    - rvm: rbx
+      env: TASK="yaks:rspec --trace"
+    - rvm: rbx
+      env: TASK="yaks-html:rspec --trace"
     - rvm: 2.2
       env: TASK=ataru
     - rvm: 2.2


### PR DESCRIPTION
Rbx has been failing a few times on Travis ( #73 ). Since I couldn't reproduce it locally, I added the --trace option to rbx tasks on Travis so that we can have more details about the errors. 