### PR TITLE
Fixed #82

### DIFF
--- a/yaks/README.md
+++ b/yaks/README.md
@@ -740,8 +740,6 @@ The lookup we'll be done as followed.
  * `Mappers::Stuff::BasicObjectMapper`
  * `Mappers::WidgetMapper`
  * `Mappers::ThingMapper`
- * `Mappers::ObjectMapper`
- * `Mappers::BasicObjectMapper`
 
 * If the `namespace` option is not set:
  * `Stuff::WidgetMapper`
@@ -750,8 +748,6 @@ The lookup we'll be done as followed.
  * `Stuff::BasicObjectMapper`
  * `WidgetMapper`
  * `ThingMapper`
- * `ObjectMapper`
- * `BasicObjectMapper`
 
 If none of these are found an error is raised.
 

--- a/yaks/lib/yaks/default_policy.rb
+++ b/yaks/lib/yaks/default_policy.rb
@@ -127,7 +127,8 @@ module Yaks
 
     def next_class_for_lookup(item, namespaces, klass)
       superclass = klass.superclass
-      return superclass if namespaces.empty? || superclass
+      return superclass if superclass < Object
+      return nil if namespaces.empty?
       namespaces.clear
       item.class
     end

--- a/yaks/spec/support/classes_for_policy_testing.rb
+++ b/yaks/spec/support/classes_for_policy_testing.rb
@@ -22,6 +22,8 @@ end
 
 class HomeMapper; end
 class WheatMapper; end
+class ObjectMapper; end
+class BasicObjectMapper; end
 
 module MyMappers
   class SoyMapper; end

--- a/yaks/spec/unit/yaks/default_policy/derive_mapper_from_item_spec.rb
+++ b/yaks/spec/unit/yaks/default_policy/derive_mapper_from_item_spec.rb
@@ -96,4 +96,19 @@ RSpec.describe Yaks::DefaultPolicy, '#derive_mapper_from_item' do
       end
     end
   end
+
+  context 'Object instance' do
+    it 'return ObjectMapper' do
+      expect(policy.derive_mapper_from_item(Object.new)).to be ObjectMapper
+    end
+
+    context 'no mapper available' do
+      before { Object.send(:remove_const, "ObjectMapper") }
+      after  { Object::ObjectMapper = Class.new }
+
+      it 'raise error' do
+        expect { policy.derive_mapper_from_item(Object.new) }.to raise_error RuntimeError
+      end
+    end
+  end
 end


### PR DESCRIPTION
Object and BasicObject are not looked up anymore.
I also figured out that if you try to derive a `BasicObject` instance, it results in a `NoMethodError`. But honestly, I don't see why somebody would try to derive a `BasicObject` so I'm not sure if this case should be treated and tested.