### PR TITLE
Primitivize time objects by default

### DIFF
--- a/yaks/README.md
+++ b/yaks/README.md
@@ -769,6 +769,8 @@ For JSON based formats, the "syntax tree" is merely a structure of Ruby primitiv
 
 ```ruby
 Yaks.new do
+  # JSON specification doesn't standardize time formats, so Yaks doesn't imply
+  # any as well, but in most cases it's best you use the global ISO8601 standard.
   map_to_primitive Date, Time, DateTime do |date|
     date.iso8601
   end


### PR DESCRIPTION
Since ISO8601 is the standard for time objects, I think we should do this primitivization by default in Yaks. Date/Time objects are pretty common, so I think this change would be friendly to newcomers, and users will almost always want ISO8601.