### PR TITLE
Make sure empty Link options share the same instance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+AllCops:
+  Exclude:
+    - 'pkg/**/*'
+
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - 'pkg/**/*'
+    - 'vendor/**/*'
 
 Lint/AmbiguousRegexpLiteral:
   Enabled: false

--- a/yaks/lib/yaks/mapper/link.rb
+++ b/yaks/lib/yaks/mapper/link.rb
@@ -25,7 +25,7 @@ module Yaks
     #   it will receive the mapper instance as argument. Otherwise it is evaluated in the mapper context
     class Link
       extend Forwardable, Util
-      include Attribs.new(:rel, :template, options: {}), Util
+      include Attribs.new(:rel, :template, options: {}.freeze), Util
 
       def self.create(*args)
         args, options = extract_options(args)
@@ -62,11 +62,16 @@ module Yaks
         uri = mapper.expand_uri(template, options.fetch(:expand, true))
         return if uri.nil?
 
-        Resource::Link.new(
+        attrs = {
           rel: rel,
-          uri: uri,
-          options: resource_link_options(mapper)
-        )
+          uri: uri
+        }
+
+        resource_link_options(mapper).tap do |opts|
+          attrs[:options] = opts unless opts.empty?
+        end
+
+        Resource::Link.new(attrs)
       end
 
       private

--- a/yaks/lib/yaks/resource/link.rb
+++ b/yaks/lib/yaks/resource/link.rb
@@ -1,7 +1,7 @@
 module Yaks
   class Resource
     class Link
-      include Attribs.new(:rel, :uri, options: {})
+      include Attribs.new(:rel, :uri, options: {}.freeze)
 
       def title
         options[:title]


### PR DESCRIPTION
The main reason is that this way doing a `pp` on a `Yaks::Resource` will be more compact. Empty link option hashes will not be rendered because they will be identical to the default.

Also made sure `rubocop` ignores files under `pkg`, these are leftovers from locally building a gem.