### PR TITLE
WIP: Updated JSON-API to match 1.0 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### master
 [all changes](http://github.com/plexus/yaks/compare/v0.10.0...master)
 
+* Updated JSON-API to match 1.0 format.
+
 ### v0.10.0 / 2015-05-19
 [all changes](http://github.com/plexus/yaks/compare/v0.9.0...v0.10.0)
 

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -54,16 +54,19 @@ module Yaks
       # @return [Hash]
       def serialize_relationships(subresources)
         subresources.each_with_object({}) do |resource, hsh|
-          next if resource.null_resource?
-          hsh[resource.rels.first.sub(/^rel:/, '')] = serialize_relationship(resource)
+          hsh[resource.rels.first.sub(/^rel:/, '').to_sym] = serialize_relationship(resource)
         end
       end
 
       # @param [Yaks::Resource] resource
       # @return [Array, Hash]
       def serialize_relationship(resource)
-        return {data: resource.map{|r| {type: pluralize(r.type), id: r[:id].to_s} }} if resource.collection?
-        {data: {type: pluralize(resource.type), id: resource[:id].to_s}}
+        if resource.collection?
+          data = resource.map { |r| {type: pluralize(r.type), id: r[:id].to_s} }
+        elsif !resource.null_resource?
+          data = {type: pluralize(resource.type), id: resource[:id].to_s}
+        end
+        {data: data}
       end
 
       # @param [Hash] subresources

--- a/yaks/lib/yaks/reader/json_api.rb
+++ b/yaks/lib/yaks/reader/json_api.rb
@@ -12,12 +12,12 @@ module Yaks
         else
           attributes = parsed_json['data'].dup
           links = attributes.delete('links') || {}
+          relationships = attributes.delete('relationships') || {}
           type  = attributes.delete('type')
           attributes.merge!(attributes.delete('attributes') || {})
 
-          association_links, resource_links = links.partition { |_k, v| v.is_a?(Hash) }
-          embedded   = convert_embedded(Hash[association_links], included)
-          links      = convert_links(Hash[resource_links])
+          embedded   = convert_embedded(Hash[relationships], included)
+          links      = convert_links(Hash[links])
 
           Resource.new(
             type: Util.singularize(type),
@@ -30,27 +30,27 @@ module Yaks
 
       def convert_embedded(links, included)
         links.flat_map do |rel, link_data|
-          # A Link doesn't have to contain a `linkage` member.
+          # A Link doesn't have to contain a `data` member.
           # It can contain URLs instead, or as well, but we are only worried about *embedded* links here.
-          linkage = link_data['linkage']
-          # Resource linkage MUST be represented as one of the following:
+          data = link_data['data']
+          # Resource data MUST be represented as one of the following:
           #
           # * `null` for empty to-one relationships.
-          # * a "linkage object" for non-empty to-one relationships.
+          # * a "resource identifier object" for non-empty to-one relationships.
           # * an empty array ([]) for empty to-many relationships.
-          # * an array of linkage objects for non-empty to-many relationships.
-          if linkage.nil?
+          # * an array of resource identifier objects for non-empty to-many relationships.
+          if data.nil?
             nil
-          elsif linkage.is_a? Array
+          elsif data.is_a? Array
             CollectionResource.new(
-              members: linkage.map { |link|
+              members: data.map { |link|
                 data = included.find{ |item| (item['id'] == link['id']) && (item['type'] == link['type']) }
                 call('data'  => data, 'included' => included)
               },
               rels: [rel]
             )
           else
-            data = included.find{ |item| (item['id'] == linkage['id']) && (item['type'] == linkage['type']) }
+            data = included.find{ |item| (item['id'] == data['id']) && (item['type'] == data['type']) }
             call('data'  => data, 'included' => included).with(rels: [rel])
           end
         end.compact

--- a/yaks/spec/json/confucius.json_api.json
+++ b/yaks/spec/json/confucius.json_api.json
@@ -7,12 +7,16 @@
       "pinyin": "Kongzi",
       "latinized": "Confucius"
     },
-    "links": {
-      "profile": "http://literature.example.com/profiles/scholar",
+    "relationships": {
+      "works": {
+        "data": [{"type": "works", "id": "11"}, {"type": "works", "id": "12"}]
+      }
+    },
+		"links": {
+  	  "profile": "http://literature.example.com/profiles/scholar",
       "self": "http://literature.example.com/authors/kongzi",
-      "http://literature.example.com/rels/quotes": "http://literature.example.com/quotes/?author=kongzi&q={query}",
-      "works": {"linkage": [{"type": "works", "id": "11"}, {"type": "works", "id": "12"}]}
-    }
+			"http://literature.example.com/rels/quotes": "http://literature.example.com/quotes/?author=kongzi&q={query}"
+	  }
   },
   "included": [
       {
@@ -22,11 +26,15 @@
           "chinese_name": "論語",
           "english_name": "Analects"
         },
+        "relationships": {
+          "quotes": {
+            "data": [{"type": "quotes", "id": "17"}, {"type": "quotes", "id": "18"}]
+          },
+          "era": {"data": {"type": "erae", "id": "99"}}
+        },
         "links": {
           "profile": "http://literature.example.com/profiles/work",
-          "self": "http://literature.example.com/work/11",
-          "quotes": {"linkage": [{"type": "quotes", "id": "17"}, {"type": "quotes", "id": "18"}]},
-          "era": {"linkage": {"type": "erae", "id": "99"}}
+          "self": "http://literature.example.com/work/11"
         }
       },
       {

--- a/yaks/spec/json/confucius.json_api.json
+++ b/yaks/spec/json/confucius.json_api.json
@@ -65,6 +65,10 @@
           "chinese_name": "易經",
           "english_name": "Commentaries to the Yi-jing"
         },
+        "relationships": {
+          "quotes": { "data": [] },
+          "era": { "data": null }
+        },
         "links": {
           "profile": "http://literature.example.com/profiles/work",
           "self": "http://literature.example.com/work/12"

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Yaks::Format::JsonAPI do
         data: {
           type: 'wizards',
           relationships: {
-            'favourite_spell' => {data: {type: "spells", id: "1"}}
+            favourite_spell: {data: {type: "spells", id: "1"}}
           },
           links: {
             self: "/the/self/link",
@@ -74,7 +74,7 @@ RSpec.describe Yaks::Format::JsonAPI do
       expect(format.call(resource)).to eql(
         data: {
           type: 'wizards',
-          relationships: {'favourite_spell'  => {data: {type: 'spells', id: "777"}}}
+          relationships: {favourite_spell: {data: {type: 'spells', id: "777"}}}
         },
         included: [{type: 'spells', id: "777", attributes: {name: 'Lucky Sevens'}}]
       )
@@ -105,10 +105,10 @@ RSpec.describe Yaks::Format::JsonAPI do
     it 'should include the each subresource only once' do
       expect(format.call(resource)).to eql(
         data: [
-          {type: 'wizards', id: '7', relationships: {'favourite_spell' => {data: {type: 'spells', id: '1'}}}},
-          {type: 'wizards', id: '3', relationships: {'favourite_spell' => {data: {type: 'spells', id: '1'}}}},
-          {type: 'wizards', id: '2', relationships: {'favourite_spell' => {data: {type: 'spells', id: '12'}}}},
-          {type: 'wizards', id: '9', relationships: {'wand'            => {data: {type: 'wands',  id: '1'}}}},
+          {type: 'wizards', id: '7', relationships: {favourite_spell: {data: {type: 'spells', id: '1'}}}},
+          {type: 'wizards', id: '3', relationships: {favourite_spell: {data: {type: 'spells', id: '1'}}}},
+          {type: 'wizards', id: '2', relationships: {favourite_spell: {data: {type: 'spells', id: '12'}}}},
+          {type: 'wizards', id: '9', relationships: {wand:            {data: {type: 'wands',  id: '1'}}}},
         ],
         included: [
           {type: 'spells', id: '1'},
@@ -123,14 +123,38 @@ RSpec.describe Yaks::Format::JsonAPI do
     let(:resource) {
       Yaks::Resource.new(
         type: 'wizard',
-        subresources: [Yaks::NullResource.new]
+        subresources: [subresource]
       )
     }
 
-    it 'should not include subresource links' do
-      expect(format.call(resource)).to eql(
-        data: {type: 'wizards'}
-      )
+    context "non-collection subresouce" do
+      let(:subresource) { Yaks::NullResource.new.add_rel("rel:wand") }
+
+      it 'should include a nil linkage object' do
+        expect(format.call(resource)).to eql(
+          data: {
+            type: 'wizards',
+            relationships: {
+              wand: {data: nil}
+            }
+          }
+        )
+      end
+    end
+
+    context "collection subresouce" do
+      let(:subresource) { Yaks::NullResource.new(collection: true).add_rel("rel:wands") }
+
+      it 'should include a nil linkage object' do
+        expect(format.call(resource)).to eql(
+          data: {
+            type: 'wizards',
+            relationships: {
+              wands: {data: []}
+            }
+          }
+        )
+      end
     end
   end
 

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -47,10 +47,12 @@ RSpec.describe Yaks::Format::JsonAPI do
       expect(format.call(resource)).to eql(
         data: {
           type: 'wizards',
+          relationships: {
+            'favourite_spell' => {data: {type: "spells", id: "1"}}
+          },
           links: {
             self: "/the/self/link",
-            profile: "/the/profile/link",
-            'favourite_spell' => {linkage: {type: "spells", id: "1"}},
+            profile: "/the/profile/link"
           }
         },
         included: [{type: 'spells', id: "1"}]
@@ -72,7 +74,7 @@ RSpec.describe Yaks::Format::JsonAPI do
       expect(format.call(resource)).to eql(
         data: {
           type: 'wizards',
-          links: {'favourite_spell'  => {linkage: {type: 'spells', id: "777"}}}
+          relationships: {'favourite_spell'  => {data: {type: 'spells', id: "777"}}}
         },
         included: [{type: 'spells', id: "777", attributes: {name: 'Lucky Sevens'}}]
       )
@@ -103,10 +105,10 @@ RSpec.describe Yaks::Format::JsonAPI do
     it 'should include the each subresource only once' do
       expect(format.call(resource)).to eql(
         data: [
-          {type: 'wizards', id: '7', links: {'favourite_spell' => {linkage: {type: 'spells', id: '1'}}}},
-          {type: 'wizards', id: '3', links: {'favourite_spell' => {linkage: {type: 'spells', id: '1'}}}},
-          {type: 'wizards', id: '2', links: {'favourite_spell' => {linkage: {type: 'spells', id: '12'}}}},
-          {type: 'wizards', id: '9', links: {'wand'            => {linkage: {type: 'wands',  id: '1'}}}},
+          {type: 'wizards', id: '7', relationships: {'favourite_spell' => {data: {type: 'spells', id: '1'}}}},
+          {type: 'wizards', id: '3', relationships: {'favourite_spell' => {data: {type: 'spells', id: '1'}}}},
+          {type: 'wizards', id: '2', relationships: {'favourite_spell' => {data: {type: 'spells', id: '12'}}}},
+          {type: 'wizards', id: '9', relationships: {'wand'            => {data: {type: 'wands',  id: '1'}}}},
         ],
         included: [
           {type: 'spells', id: '1'},


### PR DESCRIPTION
Changes:
* "links" is not separated into a "relationships" object and a "links" object.
* "linkage" has been changed to "data".
* null/empty relationships are now properly rendered