### PR TITLE
Output JSON-API Error Object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ Gemfile.lock
 .yardoc
 doc
 FORMATS.html
+
+*.swp
+*.swo

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -9,10 +9,10 @@ module Yaks
       # @return [Hash]
       def call(resource, _env = nil)
         output = {}
-          output[:errors]  = resource.seq.map(&method(:serialize_error))
         if resource.type.to_s.eql?('error')
+          output[:errors] = resource.seq.map(&method(:serialize_error))
         elsif resource.collection?
-          output[:data]  = resource.map(&method(:serialize_resource))
+          output[:data] = resource.map(&method(:serialize_resource))
           output[:links] = serialize_links(resource.links) if resource.links.any?
         else
           output[:data] = serialize_resource(resource)

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -9,7 +9,7 @@ module Yaks
       # @return [Hash]
       def call(resource, _env = nil)
         output = {}
-        if resource.type == :error
+        if resource.type.to_s == 'error'
           output[:errors]  = resource.seq.map(&method(:serialize_error))
         elsif resource.collection?
           output[:data]  = resource.map(&method(:serialize_resource))

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -57,7 +57,7 @@ module Yaks
       def serialize_error(resource)
         result = {}
 
-        resource.attributes.each { |k,v| result[k] = v }
+        resource.attributes.each { |k, v| result[k] = v }
 
         links = serialize_links(resource.links)
         result[:links] = links unless links.empty?

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -9,7 +9,9 @@ module Yaks
       # @return [Hash]
       def call(resource, _env = nil)
         output = {}
-        if resource.collection?
+        if resource.type == :error
+          output[:errors]  = resource.seq.map(&method(:serialize_error))
+        elsif resource.collection?
           output[:data]  = resource.map(&method(:serialize_resource))
           output[:links] = serialize_links(resource.links) if resource.links.any?
         else
@@ -44,6 +46,19 @@ module Yaks
 
         relationships = serialize_relationships(resource.subresources)
         result[:relationships] = relationships unless relationships.empty?
+        links = serialize_links(resource.links)
+        result[:links] = links unless links.empty?
+
+        result
+      end
+
+      # @param [Yaks::Resource] resource
+      # @return [Hash]
+      def serialize_error(resource)
+        result = {}
+
+        resource.attributes.each { |k,v| result[k] = v }
+
         links = serialize_links(resource.links)
         result[:links] = links unless links.empty?
 

--- a/yaks/lib/yaks/format/json_api.rb
+++ b/yaks/lib/yaks/format/json_api.rb
@@ -9,8 +9,8 @@ module Yaks
       # @return [Hash]
       def call(resource, _env = nil)
         output = {}
-        if resource.type.to_s == 'error'
           output[:errors]  = resource.seq.map(&method(:serialize_error))
+        if resource.type.to_s.eql?('error')
         elsif resource.collection?
           output[:data]  = resource.map(&method(:serialize_resource))
           output[:links] = serialize_links(resource.links) if resource.links.any?

--- a/yaks/spec/acceptance/acceptance_spec.rb
+++ b/yaks/spec/acceptance/acceptance_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Yaks::Format::JsonAPI do
   let(:yaks_config) { Yaks.new }
 
   include_examples 'JSON Writer', 'confucius'
+  include_examples 'JSON Writer', 'error'
   # include_examples 'JSON Reader', 'confucius'
   include_examples 'JSON round trip', 'confucius'
   include_examples 'JSON Writer', 'list_of_quotes'

--- a/yaks/spec/acceptance/models.rb
+++ b/yaks/spec/acceptance/models.rb
@@ -16,6 +16,10 @@ class Era
   include Anima.new(:id, :name)
 end
 
+class Error
+  include Anima.new(:id, :title, :detail, :code, :status, :source, :links)
+end
+
 class LiteratureBaseMapper < Yaks::Mapper
   link :profile, 'http://literature.example.com/profiles/{mapper_name}', expand: true
   link :self, 'http://literature.example.com/{mapper_name}/{id}'
@@ -54,4 +58,11 @@ end
 
 class EraMapper < Yaks::Mapper
   attributes :id, :name
+end
+
+class ErrorMapper < Yaks::Mapper
+  type :error
+  attributes :id, :title, :detail, :code, :status, :source, :links
+
+  link :about, 'http://example.com/errors/{code}'
 end

--- a/yaks/spec/json/error.json_api.json
+++ b/yaks/spec/json/error.json_api.json
@@ -1,0 +1,15 @@
+{
+  "errors": [
+    {
+      "id": 23,
+      "title": "Record not found",
+      "detail": "The record identified by 25 could not be found",
+      "code": "1123",
+      "status": "404",
+      "source": null,
+      "links": {
+        "about": "http://example.com/errors/1123"
+      }  
+    }
+  ]
+} 

--- a/yaks/spec/unit/yaks/format/json_api_spec.rb
+++ b/yaks/spec/unit/yaks/format/json_api_spec.rb
@@ -2,6 +2,16 @@
 RSpec.describe Yaks::Format::JsonAPI do
   let(:format) { Yaks::Format::JsonAPI.new }
 
+  context 'error object should not include type' do
+    let(:resource) { Yaks::Resource.new(type: 'error', attributes: {foo: :bar}) }
+
+    it 'should not include "type" for errors' do
+      expect(format.call(resource)).to eql(
+        errors: [{foo: :bar}]
+      )
+    end
+  end
+
   context 'with no subresources' do
     let(:resource) { Yaks::Resource.new(type: 'wizard', attributes: {foo: :bar}) }
 

--- a/yaks/spec/yaml/error.yaml
+++ b/yaks/spec/yaml/error.yaml
@@ -1,0 +1,7 @@
+--- !ruby/object:Error
+  id: 23
+  title: "Record not found"
+  detail: "The record identified by 25 could not be found"
+  code: "1123"
+  status: "404"
+  source: null


### PR DESCRIPTION
This request adds an error serializer method to generate correctly formatted JSON-API error object. Previously there was no error serializer for JSON-API which caused errors mappers to render incorrectly. Details on the JSON-API [error object](http://jsonapi.org/format/#errors) format are listed in the docs .
