### PR TITLE
Rubocop errors

### DIFF
--- a/yaks/find_missing_tests.rb
+++ b/yaks/find_missing_tests.rb
@@ -20,7 +20,7 @@ env = Mutant::Env::Bootstrap.call(Mutant::CLI.call(args))
 integration = env.config.integration
 
 integration.setup
-binding.pry if integration.all_tests.empty?      # rubocop:disable Lint/Debugger
+binding.pry if integration.all_tests.empty? # rubocop:disable Lint/Debugger
 
 env.subjects.each do |subject|
   match_expression = subject.match_expressions.first

--- a/yaks/lib/yaks/format/halo.rb
+++ b/yaks/lib/yaks/format/halo.rb
@@ -21,7 +21,7 @@ module Yaks
 
       def serialize_form(form)
         raw = form.to_h_compact
-        raw[:href]  = raw.delete(:action) if raw[:action]
+        raw[:href] = raw.delete(:action) if raw[:action]
         raw[:fields] = form.fields.map(&method(:serialize_form_field))
         raw
       end

--- a/yaks/lib/yaks/mapper/association_mapper.rb
+++ b/yaks/lib/yaks/mapper/association_mapper.rb
@@ -9,7 +9,7 @@ module Yaks
         @context       = context.merge(
           mapper_stack: context[:mapper_stack] + [parent_mapper]
         )
-        @rel           = association.map_rel(policy)
+        @rel           = association.map_rel(policy) # rubocop:disable Style/ExtraSpacing
       end
 
       def policy

--- a/yaks/lib/yaks/null_resource.rb
+++ b/yaks/lib/yaks/null_resource.rb
@@ -14,7 +14,7 @@ module Yaks
       to_enum
     end
 
-    def collection?
+    def collection? # rubocop:disable Style/TrivialAccessors
       @collection
     end
 

--- a/yaks/lib/yaks/reader/json_api.rb
+++ b/yaks/lib/yaks/reader/json_api.rb
@@ -7,13 +7,13 @@ module Yaks
         if parsed_json['data'].is_a?(Array)
           CollectionResource.new(
             attributes: parsed_json['meta'].nil? ? nil : {meta: parsed_json['meta']},
-            members: parsed_json['data'].map { |data| call('data'  => data, 'included' => included) }
+            members: parsed_json['data'].map { |data| call('data' => data, 'included' => included) }
           )
         else
           attributes = parsed_json['data'].dup
           links = attributes.delete('links') || {}
           relationships = attributes.delete('relationships') || {}
-          type  = attributes.delete('type')
+          type = attributes.delete('type')
           attributes.merge!(attributes.delete('attributes') || {})
 
           embedded   = convert_embedded(Hash[relationships], included)
@@ -48,14 +48,14 @@ module Yaks
               CollectionResource.new(
                 members: data.map { |link|
                   data = included.find{ |item| (item['id'] == link['id']) && (item['type'] == link['type']) }
-                  call('data'  => data, 'included' => included)
+                  call('data' => data, 'included' => included)
                 },
                 rels: [rel]
               )
             end
           else
             data = included.find{ |item| (item['id'] == data['id']) && (item['type'] == data['type']) }
-            call('data'  => data, 'included' => included).with(rels: [rel])
+            call('data' => data, 'included' => included).with(rels: [rel])
           end
         end.compact
       end

--- a/yaks/lib/yaks/resource/form.rb
+++ b/yaks/lib/yaks/resource/form.rb
@@ -18,7 +18,7 @@ module Yaks
         !method.nil? && method.downcase.to_sym == meth.downcase.to_sym
       end
 
-      def has_action?                      # rubocop:disable Style/PredicateName
+      def has_action? # rubocop:disable Style/PredicateName
         !action.nil?
       end
     end

--- a/yaks/lib/yaks/util.rb
+++ b/yaks/lib/yaks/util.rb
@@ -46,7 +46,7 @@ module Yaks
     #   A proc or a plain value
     # @param [Object] context
     #   (optional) A context used to instance_eval the proc
-    def Resolve(maybe_proc, context = nil)    # rubocop:disable Style/MethodName
+    def Resolve(maybe_proc, context = nil) # rubocop:disable Style/MethodName
       if maybe_proc.respond_to?(:to_proc) && !maybe_proc.instance_of?(Symbol)
         if context
           if maybe_proc.arity > 0

--- a/yaks/spec/acceptance/acceptance_spec.rb
+++ b/yaks/spec/acceptance/acceptance_spec.rb
@@ -70,6 +70,6 @@ RSpec.describe Yaks::Format::CollectionJson do
       end
     }
 
-    include_examples 'JSON Writer',  'youtypeitwepostit'
+    include_examples 'JSON Writer', 'youtypeitwepostit'
   end
 end

--- a/yaks/spec/acceptance/json_shared_examples.rb
+++ b/yaks/spec/acceptance/json_shared_examples.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples_for 'JSON Writer' do |fixture_name|
   describe 'Yaks::Resource => JSON' do
-    let(:object)  { load_yaml_fixture(fixture_name) }
+    let(:object) { load_yaml_fixture(fixture_name) }
     let(:json_fixture) { load_json_fixture("#{fixture_name}.#{format_name}") }
     let(:serialized) {
       yaks_config.call(object, hooks: [[:skip, :serialize]], format: format_name)

--- a/yaks/spec/unit/yaks/config_spec.rb
+++ b/yaks/spec/unit/yaks/config_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Yaks::Config do
       its(:default_format)      { should equal :hal }
       its(:policy_class)        { should <= Yaks::DefaultPolicy }
       its(:primitivize)         { should be_a Yaks::Primitivize }
-      its(:serializers)         { should eql(Yaks::Serializer.all)  }
-      its(:hooks)               { should eql([])  }
-      its(:format_options_hash) { should eql({})}
+      its(:serializers)         { should eql(Yaks::Serializer.all) }
+      its(:hooks)               { should eql([]) }
+      its(:format_options_hash) { should eql({}) }
     end
   end
 

--- a/yaks/spec/unit/yaks/format/collection_json_spec.rb
+++ b/yaks/spec/unit/yaks/format/collection_json_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe Yaks::Format::CollectionJson do
               ],
               "queries" => [
                 {"href" => "/foo", "rel" => "search", "prompt" => "My query prompt",
-                 "data" =>                   [
+                 "data" => [
                     {"name" => "foo", "value" => ""},
                     {"name" => "bar", "value" => "", "prompt" => "My Bar Field"}
                   ]

--- a/yaks/spec/unit/yaks/mapper/association_spec.rb
+++ b/yaks/spec/unit/yaks/mapper/association_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Yaks::Mapper::Association do
     end
 
     context 'with a truthy condition' do
-      let(:if)     { ->{ true } }
+      let(:if) { ->{ true } }
 
       it 'should add the association' do
         expect(association.add_to_resource(Yaks::Resource.new, parent_mapper, yaks_context).subresources.length).to be 1
@@ -70,7 +70,7 @@ RSpec.describe Yaks::Mapper::Association do
     end
 
     context 'with a falsey condition' do
-      let(:if)     { ->{ false } }
+      let(:if) { ->{ false } }
 
       it 'should not add the association' do
         expect(association.add_to_resource(Yaks::Resource.new, parent_mapper, yaks_context).subresources.length).to be 0
@@ -182,7 +182,7 @@ RSpec.describe Yaks::Mapper::Association do
     end
 
     it 'should not munge the options hash' do
-      opts  = {mapper: :foo}
+      opts = {mapper: :foo}
       association_class.create(:foo, opts)
       expect(opts).to eql(mapper: :foo)
     end

--- a/yaks/spec/unit/yaks/mapper/form/fieldset_spec.rb
+++ b/yaks/spec/unit/yaks/mapper/form/fieldset_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Yaks::Mapper::Form::Fieldset do
 
     context "with extra options" do
       let(:fieldset) {
-        described_class.create if: true  do
+        described_class.create if: true do
           text :first_name
         end
       }

--- a/yaks/spec/unit/yaks/mapper/has_many_spec.rb
+++ b/yaks/spec/unit/yaks/mapper/has_many_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Yaks::Mapper::HasMany do
   describe '#collection_mapper' do
     let(:collection_mapper) { Yaks::Undefined }
 
-    subject(:has_many)  { described_class.new(name: :name, item_mapper: :mapper, rel: :rel, collection_mapper: collection_mapper) }
+    subject(:has_many) { described_class.new(name: :name, item_mapper: :mapper, rel: :rel, collection_mapper: collection_mapper) }
 
     context 'when the collection mapper is undefined' do
       it 'should derive one from collection and policy' do

--- a/yaks/spec/unit/yaks/mapper/has_one_spec.rb
+++ b/yaks/spec/unit/yaks/mapper/has_one_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Yaks::Mapper::HasOne do
 
   AuthorMapper = Class.new(Yaks::Mapper) { attributes :name }
 
-  subject(:has_one)  do
+  subject(:has_one) do
     described_class.new(
       name: :author,
       item_mapper: association_mapper,

--- a/yaks/spec/unit/yaks/pipeline_spec.rb
+++ b/yaks/spec/unit/yaks/pipeline_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Yaks::Pipeline do
   end
 
   describe '#insert_hooks' do
-    let(:hooks)   { [] }
+    let(:hooks) { [] }
 
     describe 'before' do
       let(:hooks) { [[:before, :step2, :before_step2, ->(i, _e) { i - (i % 100) }]] }

--- a/yaks/spec/unit/yaks/resource/link_spec.rb
+++ b/yaks/spec/unit/yaks/resource/link_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Yaks::Resource::Link do
   its(:options) { should eql(title: 'mr. spectacular') }
 
   describe '#title' do
-    its(:title)      { should eql('mr. spectacular') }
+    its(:title) { should eql('mr. spectacular') }
   end
 
   describe '#templated?' do

--- a/yaks/spec/unit/yaks/runner_spec.rb
+++ b/yaks/spec/unit/yaks/runner_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Yaks::Runner do
     let(:runner) {
       Class.new(described_class) do
         def steps
-          [ [:step1, proc { |x| x + 35      }],
+          [ [:step1, proc { |x| x + 35 }],
             [:step2, proc { |x, env| "#{env[:foo]}[#{x} #{x}]" }] ]
         end
       end.new(object: object, config: config, options: options)
@@ -337,7 +337,7 @@ RSpec.describe Yaks::Runner do
       }
     }
 
-    let(:object)  { "foo" }
+    let(:object) { "foo" }
 
     it 'should only run the mapper' do
       expect(runner.map).to eql "mapped[foo]"


### PR DESCRIPTION
Fixes Rubocop errors when using Rubocop 0.33.0. `Style/ExtraSpacing` is now enabled by default which causes most of the errors. 