### PR TITLE
Build maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 doc
 FORMATS.html
 scratch
+Jarfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3.0
   - jruby
   - jruby-head
   - ruby-head
@@ -38,5 +39,3 @@ matrix:
       env: TASK=ataru
     - rvm: 2.2
       env: TASK=mutant
-    - rvm: 2.2
-      env: TASK=rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,9 @@ gemspec path: 'yaks-html'
 gemspec path: 'yaks-transit'
 gemspec path: 'yaks-sinatra'
 
+if RUBY_VERSION < '2'
+  gem 'mime-types', [ '>= 2.6.2', '< 3' ]
+end
+
 # gem 'mutant', github: 'mbj/mutant'
 # gem 'mutant-rspec', github: 'mbj/mutant'

--- a/yaks/spec/unit/yaks/configurable_spec.rb
+++ b/yaks/spec/unit/yaks/configurable_spec.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class Kitten
   include Attribs.new(:furriness)
 


### PR DESCRIPTION
Make sure the Travis build keeps chugging along nicely.

- Lock down the version of mime-types on 1.9.3
- require SecureRandom where it's used
- ignore JRuby's Jarfile.lock
- drop Rubocop from the matrix
- Add Ruby 2.3 to the matrix