### PR TITLE
Updated logo image src

### DIFF
--- a/yaks/README.md
+++ b/yaks/README.md
@@ -10,7 +10,7 @@
 
 # Yaks
 
-<img align="left" src="https://raw.githubusercontent.com/plexus/yaks/master/logo.png">
+<img align="left" src="https://raw.githubusercontent.com/plexus/yaks/master/graphics/logo.png">
 
 The library that understands hypermedia.
 


### PR DESCRIPTION
It seems that the logo was moved under /graphics/

Perhaps this is why it's 404?